### PR TITLE
✨ Allow relative URLs in bottom bar

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -126,7 +126,8 @@ func Init() {
 				reset()
 				return
 			}
-			if query[0] == '.' && tabs[tab].hasContent() { // relative url
+			if query[0] == '.' && tabs[tab].hasContent() {
+				// Relative url
 				current, err := url.Parse(tabs[tab].page.Url)
 				if err != nil {
 					// This shouldn't occur
@@ -134,8 +135,7 @@ func Init() {
 				}
 				target, err := current.Parse(query)
 				if err != nil {
-					// invalid relative url
-					reset()
+					// Invalid relative url
 					return
 				}
 				URL(target.String())

--- a/display/display.go
+++ b/display/display.go
@@ -3,7 +3,6 @@ package display
 import (
 	"fmt"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 
@@ -127,27 +126,19 @@ func Init() {
 				reset()
 				return
 			}
-			if query == ".." && tabs[tab].hasContent() {
-				// Go up a directory
-				parsed, err := url.Parse(tabs[tab].page.Url)
+			if query[0] == '.' && tabs[tab].hasContent() { // relative url
+				current, err := url.Parse(tabs[tab].page.Url)
 				if err != nil {
 					// This shouldn't occur
 					return
 				}
-				if parsed.Path == "/" {
-					// Can't go up further
+				target, err := current.Parse(query)
+				if err != nil {
+					// invalid relative url
 					reset()
 					return
 				}
-
-				// Ex: /test/foo/ -> /test/foo//.. -> /test -> /test/
-				parsed.Path = path.Clean(parsed.Path+"/..") + "/"
-				if parsed.Path == "//" {
-					// Fix double slash that occurs at domain root
-					parsed.Path = "/"
-				}
-				parsed.RawQuery = "" // Remove query
-				URL(parsed.String())
+				URL(target.String())
 				return
 			}
 


### PR DESCRIPTION
Side effects:
If the URL does not end in /, any ./ action will actually operate on the parent directory.
For example, if the current path is /a/b/c, ./d will go to /a/b/d.
This is expected in the RFC (as far as I can tell), but it's a potential "gotcha" in case of naive servers & co.

Fixes #71