### PR TITLE
Prevent panic on empty meta with 40/50 response codes

### DIFF
--- a/display/modals.go
+++ b/display/modals.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 	"github.com/gdamore/tcell"
 	"github.com/makeworld-the-better-one/amfora/config"
 	"github.com/spf13/viper"
@@ -154,10 +154,13 @@ func modalInit() {
 
 // Error displays an error on the screen in a modal.
 func Error(title, text string) {
-	// Capitalize and add period if necessary - because most errors don't do that
-	text = strings.ToUpper(string([]rune(text)[0])) + text[1:]
-	if !strings.HasSuffix(text, ".") && !strings.HasSuffix(text, "!") && !strings.HasSuffix(text, "?") {
-		text += "."
+	if text == "" {
+		text = "No additional information."
+	} else {
+		text = strings.ToUpper(string([]rune(text)[0])) + text[1:]
+		if !strings.HasSuffix(text, ".") && !strings.HasSuffix(text, "!") && !strings.HasSuffix(text, "?") {
+			text += "."
+		}
 	}
 	// Add spaces to title for aesthetic reasons
 	title = " " + strings.TrimSpace(title) + " "


### PR DESCRIPTION
In the case that no meta information is provided when a 40/50 response is returned, amfora currently panics when trying to title case the text and add punctuation. The Gemini "spec" doesn't require meta to be populated, so this case may need to be handled.

```
The contents of <META> may provide additional information on the failure, and should be displayed to human users.
```