### PR TITLE
✨Add option to open unknown URLs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,7 @@ func Init() error {
 	viper.SetDefault("a-general.page_max_time", 10)
 	viper.SetDefault("a-general.emoji_favicons", false)
 	viper.SetDefault("keybindings.shift_numbers", "!@#$%^&*()")
+	viper.SetDefault("url-handlers.other", "off")
 	viper.SetDefault("cache.max_size", 0)
 	viper.SetDefault("cache.max_pages", 20)
 

--- a/config/default.go
+++ b/config/default.go
@@ -58,6 +58,20 @@ emoji_favicons = false
 shift_numbers = "!@#$%^&*()"
 
 
+[url-handlers]
+# Allows setting the commands to run for various URL schemes.
+# E.g. to open FTP URLs with FileZilla set the following key:
+#   ftp = "filezilla"
+# You can set any scheme to "off" to disable handling it.
+#
+# DO NOT use this for setting the HTTP command.
+# Use the http setting in the "a-general" section above
+
+# This is a special key that defines the handler for all URL schemes for which
+# no handler is defined.
+other = "off"
+
+
 [cache]
 # Options for page cache - which is only for text/gemini pages
 # Increase the cache size to speed up browsing at the expense of memory

--- a/default-config.toml
+++ b/default-config.toml
@@ -55,6 +55,20 @@ emoji_favicons = false
 shift_numbers = "!@#$%^&*()"
 
 
+[url-handlers]
+# Allows setting the commands to run for various URL schemes.
+# E.g. to open FTP URLs with FileZilla set the following key:
+#   ftp = "filezilla"
+# You can set any scheme to "off" to disable handling it.
+#
+# DO NOT use this for setting the HTTP command.
+# Use the http setting in the "a-general" section above
+
+# This is a special key that defines the handler for all URL schemes for which
+# no handler is defined.
+other = "off"
+
+
 [cache]
 # Options for page cache - which is only for text/gemini pages
 # Increase the cache size to speed up browsing at the expense of memory

--- a/display/private.go
+++ b/display/private.go
@@ -161,6 +161,30 @@ func handleHTTP(u string, showInfo bool) {
 	App.Draw()
 }
 
+// handleOther is used by handleURL.
+// It opens links other than Gemini and HTTP and displays Error modals.
+func handleOther(u string) {
+	// The URL should have a scheme due to a previous call to normalizeURL
+	parsed, _ := url.Parse(u)
+	// Search for a handler for the URL scheme
+	handler := strings.TrimSpace(viper.GetString("url-handlers." + parsed.Scheme))
+	if len(handler) == 0 {
+		handler = strings.TrimSpace(viper.GetString("url-handlers.other"))
+	}
+	switch handler {
+	case "", "off":
+		Error("URL Error", "Opening " + parsed.Scheme + " URLs is turned off.")
+	default:
+		// The config has a custom command to execute for URLs
+		fields := strings.Fields(handler)
+		err := exec.Command(fields[0], append(fields[1:], u)...).Start()
+		if err != nil {
+			Error("URL Error", "Error executing custom command: " + err.Error())
+		}
+	}
+	App.Draw()
+}
+
 // handleFavicon handles getting and displaying a favicon.
 // `old` is the previous favicon for the tab.
 func handleFavicon(t *tab, host, old string) {
@@ -307,7 +331,7 @@ func handleURL(t *tab, u string) (string, bool) {
 		return ret("", false)
 	}
 	if !strings.HasPrefix(u, "gemini") {
-		Error("Protocol Error", "Only gemini and HTTP are supported. URL was "+u)
+		handleOther(u)
 		return ret("", false)
 	}
 	// Gemini URL


### PR DESCRIPTION
A new config option that sets a command to open unsupported URL schemes (e.g. `gopher://`). It is unset by default to keep the previous behavior.