### PR TITLE
Fix build error on darwin OS

### DIFF
--- a/webbrowser/open_browser_unix.go
+++ b/webbrowser/open_browser_unix.go
@@ -1,4 +1,5 @@
 // +build linux freebsd netbsd openbsd
+
 //nolint:goerr113
 package webbrowser
 


### PR DESCRIPTION
This fixes an error that prevented a successful build on darwin machines.

The error message was:

```
webbrowser/open_browser_unix.go:15:6: Open redeclared in this block
	previous declaration at webbrowser/open_browser_darwin.go:7:32
```

The issue was the build constraint in webbrowser/open_browser_unix.go
was being ignored because there was not a blank line following the build
constraint line.

I discovered the solution from here:
https://stackoverflow.com/questions/10646531/golang-conditional-compilation