### PR TITLE
Fixes #55 - ignore navigation keypresses while help is open

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -229,6 +229,11 @@ func Init() {
 			// It's focused on a modal right now, nothing should interrupt
 			return event
 		}
+		_, ok = App.GetFocus().(*cview.Table)
+		if ok {
+			// It's focused on help right now
+			return event
+		}
 
 		if tabs[curTab].mode == tabModeDone {
 			// All the keys and operations that can only work while NOT loading

--- a/display/help.go
+++ b/display/help.go
@@ -12,12 +12,14 @@ var helpCells = strings.TrimSpace(`
 ?|Bring up this help. You can scroll!
 Esc|Leave the help
 Arrow keys, h/j/k/l|Scroll and move a page.
+PgUp, u|Go up a page in document
+PgDn, d|Go down a page in document
+g|Go to top of document
+G|Go to bottom of document
 Tab|Navigate to the next item in a popup.
 Shift-Tab|Navigate to the previous item in a popup.
 b, Alt-Left|Go back in the history
 f, Alt-Right|Go forward in the history
-g|Go to top of document
-G|Go to bottom of document
 spacebar|Open bar at the bottom - type a URL, link number, search term.
 |You can also type two dots (..) to go up a directory in the URL.
 |Typing new:N will open link number N in a new tab
@@ -60,7 +62,7 @@ func Help() {
 func helpInit() {
 	// Populate help table
 	helpTable.SetDoneFunc(func(key tcell.Key) {
-		if key == tcell.KeyEsc {
+		if key == tcell.KeyEsc || key == tcell.KeyEnter {
 			tabPages.SwitchToPage(strconv.Itoa(curTab))
 			App.SetFocus(tabs[curTab].view)
 			App.Draw()


### PR DESCRIPTION
The issues is that keypresses while the help is open are applied on the current document "underneath" the help table. This solution employs a similar technique that is used to ignore disallowed keypresses while a modal is open.

I also updated the help message to include help on page-up, page-down, u and d which were missing.

I also updated it to allow pressing enter to close the help too.