### PR TITLE
Custom new tab page

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 var amforaAppData string // Where amfora files are stored on Windows - cached here
-var configDir string
+var ConfigDir string
 var configPath string
 
 var TofuStore = viper.New()
@@ -48,18 +48,18 @@ func Init() error {
 
 	// Store config directory and file paths
 	if runtime.GOOS == "windows" {
-		configDir = amforaAppData
+		ConfigDir = amforaAppData
 	} else {
 		// Unix / POSIX system
 		xdg_config, ok := os.LookupEnv("XDG_CONFIG_HOME")
 		if ok && strings.TrimSpace(xdg_config) != "" {
-			configDir = filepath.Join(xdg_config, "amfora")
+			ConfigDir = filepath.Join(xdg_config, "amfora")
 		} else {
 			// Default to ~/.config/amfora
-			configDir = filepath.Join(home, ".config", "amfora")
+			ConfigDir = filepath.Join(home, ".config", "amfora")
 		}
 	}
-	configPath = filepath.Join(configDir, "config.toml")
+	configPath = filepath.Join(ConfigDir, "config.toml")
 
 	// Store TOFU db directory and file paths
 	if runtime.GOOS == "windows" {
@@ -96,7 +96,7 @@ func Init() error {
 	// Create necessary files and folders
 
 	// Config
-	err = os.MkdirAll(configDir, 0755)
+	err = os.MkdirAll(ConfigDir, 0755)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ var configDir string
 var configPath string
 
 var NewTabPath string
+var CustomNewTab bool
 
 var TofuStore = viper.New()
 var tofuDBDir string
@@ -65,6 +66,10 @@ func Init() error {
 
 	// Search for a custom new tab
 	NewTabPath = filepath.Join(configDir, "newtab.gmi")
+	CustomNewTab = false
+	if _, err := os.Stat(NewTabPath); err == nil {
+		CustomNewTab = true
+	}
 
 	// Store TOFU db directory and file paths
 	if runtime.GOOS == "windows" {

--- a/config/config.go
+++ b/config/config.go
@@ -15,8 +15,10 @@ import (
 )
 
 var amforaAppData string // Where amfora files are stored on Windows - cached here
-var ConfigDir string
+var configDir string
 var configPath string
+
+var NewTabPath string
 
 var TofuStore = viper.New()
 var tofuDBDir string
@@ -48,18 +50,21 @@ func Init() error {
 
 	// Store config directory and file paths
 	if runtime.GOOS == "windows" {
-		ConfigDir = amforaAppData
+		configDir = amforaAppData
 	} else {
 		// Unix / POSIX system
 		xdg_config, ok := os.LookupEnv("XDG_CONFIG_HOME")
 		if ok && strings.TrimSpace(xdg_config) != "" {
-			ConfigDir = filepath.Join(xdg_config, "amfora")
+			configDir = filepath.Join(xdg_config, "amfora")
 		} else {
 			// Default to ~/.config/amfora
-			ConfigDir = filepath.Join(home, ".config", "amfora")
+			configDir = filepath.Join(home, ".config", "amfora")
 		}
 	}
-	configPath = filepath.Join(ConfigDir, "config.toml")
+	configPath = filepath.Join(configDir, "config.toml")
+
+	// Search for a custom new tab
+	NewTabPath = filepath.Join(configDir, "newtab.gmi")
 
 	// Store TOFU db directory and file paths
 	if runtime.GOOS == "windows" {
@@ -96,7 +101,7 @@ func Init() error {
 	// Create necessary files and folders
 
 	// Config
-	err = os.MkdirAll(ConfigDir, 0755)
+	err = os.MkdirAll(configDir, 0755)
 	if err != nil {
 		return err
 	}

--- a/display/display.go
+++ b/display/display.go
@@ -518,7 +518,7 @@ func SwitchTab(tab int) {
 }
 
 func Reload() {
-	if tabs[curTab].page.URL == "about:newtab" {
+	if tabs[curTab].page.URL == "about:newtab" && config.CustomNewTab {
 		// Re-render new tab, similar to Init()
 		newTabContent := getNewTabContent()
 		tmpTermW := termW

--- a/display/display.go
+++ b/display/display.go
@@ -520,6 +520,24 @@ func SwitchTab(tab int) {
 }
 
 func Reload() {
+	if tabs[curTab].page.URL == "about:newtab" {
+		// Re-render new tab, similar to Init()
+		newTabContent := getNewTabContent()
+		tmpTermW := termW
+		renderedNewTabContent, newTabLinks = renderer.RenderGemini(newTabContent, textWidth(), leftMargin())
+		newTabPage = structs.Page{
+			Raw:       newTabContent,
+			Content:   renderedNewTabContent,
+			Links:     newTabLinks,
+			URL:       "about:newtab",
+			Width:     tmpTermW,
+			Mediatype: structs.TextGemini,
+		}
+		temp := newTabPage // Copy
+		setPage(tabs[curTab], &temp)
+		return
+	}
+
 	if !tabs[curTab].hasContent() {
 		return
 	}

--- a/display/display.go
+++ b/display/display.go
@@ -202,6 +202,7 @@ func Init() {
 	})
 
 	// Render the default new tab content ONCE and store it for later
+	newTabContent := getNewTabContent()
 	renderedNewTabContent, newTabLinks = renderer.RenderGemini(newTabContent, textWidth(), leftMargin())
 	newTabPage = structs.Page{
 		Raw:       newTabContent,

--- a/display/display.go
+++ b/display/display.go
@@ -51,8 +51,6 @@ var tabRow = cview.NewTextView().
 var layout = cview.NewFlex().
 	SetDirection(cview.FlexRow)
 
-var renderedNewTabContent string
-var newTabLinks []string
 var newTabPage structs.Page
 
 var App = cview.NewApplication().
@@ -203,7 +201,7 @@ func Init() {
 
 	// Render the default new tab content ONCE and store it for later
 	newTabContent := getNewTabContent()
-	renderedNewTabContent, newTabLinks = renderer.RenderGemini(newTabContent, textWidth(), leftMargin())
+	renderedNewTabContent, newTabLinks := renderer.RenderGemini(newTabContent, textWidth(), leftMargin())
 	newTabPage = structs.Page{
 		Raw:       newTabContent,
 		Content:   renderedNewTabContent,
@@ -524,7 +522,7 @@ func Reload() {
 		// Re-render new tab, similar to Init()
 		newTabContent := getNewTabContent()
 		tmpTermW := termW
-		renderedNewTabContent, newTabLinks = renderer.RenderGemini(newTabContent, textWidth(), leftMargin())
+		renderedNewTabContent, newTabLinks := renderer.RenderGemini(newTabContent, textWidth(), leftMargin())
 		newTabPage = structs.Page{
 			Raw:       newTabContent,
 			Content:   renderedNewTabContent,

--- a/display/newtab.go
+++ b/display/newtab.go
@@ -1,4 +1,3 @@
-//nolint
 package display
 
 import (
@@ -7,6 +6,7 @@ import (
 	"github.com/makeworld-the-better-one/amfora/config"
 )
 
+//nolint
 var defaultNewTabContent = `# New Tab
 
 You've opened a new tab. Use the bar at the bottom to browse around. You can start typing in it by pressing the space key.

--- a/display/newtab.go
+++ b/display/newtab.go
@@ -30,7 +30,6 @@ func getNewTabContent() string {
 	data, err := ioutil.ReadFile(newTabFile)
 	if err == nil {
 		return string(data)
-	} else {
-		return defaultNewTabContent
 	}
+	return defaultNewTabContent
 }

--- a/display/newtab.go
+++ b/display/newtab.go
@@ -3,7 +3,6 @@ package display
 
 import (
 	"io/ioutil"
-	"path/filepath"
 
 	"github.com/makeworld-the-better-one/amfora/config"
 )
@@ -26,8 +25,7 @@ Happy browsing!
 
 // Read the new tab content from a file if it exists or fallback to a default page.
 func getNewTabContent() string {
-	newTabFile := filepath.Join(config.ConfigDir, "newtab.gmi")
-	data, err := ioutil.ReadFile(newTabFile)
+	data, err := ioutil.ReadFile(config.NewTabPath)
 	if err == nil {
 		return string(data)
 	}

--- a/display/newtab.go
+++ b/display/newtab.go
@@ -1,11 +1,24 @@
 //nolint
 package display
 
-var newTabContent = `# New Tab
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/makeworld-the-better-one/amfora/config"
+)
+
+var defaultNewTabContent = `# New Tab
 
 You've opened a new tab. Use the bar at the bottom to browse around. You can start typing in it by pressing the space key.
 
 Press the ? key at any time to bring up the help, and see other keybindings. Most are what you expect.
+
+You can customize this page by creating the Gemtext file
+
+` + "```" + `
+$XDG_CONFIG_HOME/amfora/new_tab.gmi
+` + "```" + `
 
 Happy browsing!
 
@@ -14,3 +27,14 @@ Happy browsing!
 => //gemini.circumlunar.space Project Gemini
 => https://github.com/makeworld-the-better-one/amfora Amfora homepage [HTTPS]
 `
+
+// Read the new tab content from a file if it exists or fallback to a default page.
+func getNewTabContent() string {
+	newTabFile := filepath.Join(config.ConfigDir, "new_tab.gmi")
+	data, err := ioutil.ReadFile(newTabFile)
+	if err == nil {
+		return string(data)
+	} else {
+		return defaultNewTabContent
+	}
+}

--- a/display/newtab.go
+++ b/display/newtab.go
@@ -14,11 +14,7 @@ You've opened a new tab. Use the bar at the bottom to browse around. You can sta
 
 Press the ? key at any time to bring up the help, and see other keybindings. Most are what you expect.
 
-You can customize this page by creating the Gemtext file
-
-` + "```" + `
-$XDG_CONFIG_HOME/amfora/newtab.gmi
-` + "```" + `
+You can customize this page by creating a gemtext file called newtab.gmi, in Amfora's configuration folder.
 
 Happy browsing!
 

--- a/display/newtab.go
+++ b/display/newtab.go
@@ -17,7 +17,7 @@ Press the ? key at any time to bring up the help, and see other keybindings. Mos
 You can customize this page by creating the Gemtext file
 
 ` + "```" + `
-$XDG_CONFIG_HOME/amfora/new_tab.gmi
+$XDG_CONFIG_HOME/amfora/newtab.gmi
 ` + "```" + `
 
 Happy browsing!
@@ -30,7 +30,7 @@ Happy browsing!
 
 // Read the new tab content from a file if it exists or fallback to a default page.
 func getNewTabContent() string {
-	newTabFile := filepath.Join(config.ConfigDir, "new_tab.gmi")
+	newTabFile := filepath.Join(config.ConfigDir, "newtab.gmi")
 	data, err := ioutil.ReadFile(newTabFile)
 	if err == nil {
 		return string(data)


### PR DESCRIPTION
The new tab page can now be loaded from `$XDG_CONFIG_HOME/amfora/new_tab.gmi`. This is documented in the default tab page. This implements what was suggested in issue #67 except for the ability to reload the new tab page, it is loaded once on startup.

- I didn't make the new tab file location configurable. It will require expanding `~` in the config option and possibly environment variables in order to honor `XDG_CONFIG_HOME` so I opted for a hardcoded path like the config file. If it is deemed necessary I can implement it.
- `config.ConfigDir` was exported to allow accessing `XDG_CONFIG_HOME` from outside `config`.
- I didn't implement the reload yet because it will require some special cases and I'm not sure where best to add them, `Reload()`, or `hasContent()` and `handleURL()`?