### PR TITLE
Strip ANSI codes from page based on config - fixes #79

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -206,6 +206,7 @@ func Init() error {
 	viper.SetDefault("a-general.http", "default")
 	viper.SetDefault("a-general.search", "gus.guru/search")
 	viper.SetDefault("a-general.color", true)
+	viper.SetDefault("a-general.ansi", true)
 	viper.SetDefault("a-general.bullets", true)
 	viper.SetDefault("a-general.left_margin", 0.15)
 	viper.SetDefault("a-general.max_width", 100)

--- a/config/default.go
+++ b/config/default.go
@@ -33,6 +33,9 @@ search = "gemini://gus.guru/search"
 # Whether colors will be used in the terminal
 color = true
 
+# Whether ANSI codes from the page content should be rendered
+ansi = true
+
 # Whether to replace list asterisks with unicode bullets
 bullets = true
 

--- a/default-config.toml
+++ b/default-config.toml
@@ -30,6 +30,9 @@ search = "gemini://gus.guru/search"
 # Whether colors will be used in the terminal
 color = true
 
+# Whether ANSI codes from the page content should be rendered
+ansi = true
+
 # Whether to replace list asterisks with unicode bullets
 bullets = true
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -16,9 +16,8 @@ import (
 	"gitlab.com/tslocum/cview"
 )
 
-// Regex for identifying ANSI codes; credit to pkg acarl005/stripansi
-//nolint:lll
-const ansiRegex = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+// Regex for identifying ANSI color codes
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 // RenderANSI renders plain text pages containing ANSI codes.
 // Practically, it is used for the text/x-ansi.
@@ -27,7 +26,7 @@ func RenderANSI(s string, leftMargin int) string {
 	if viper.GetBool("a-general.color") && viper.GetBool("a-general.ansi") {
 		s = cview.TranslateANSI(s)
 	} else {
-		s = stripANSI(s)
+		s = ansiRegex.ReplaceAllString(s, "")
 	}
 	var shifted string
 	lines := strings.Split(s, "\n")
@@ -274,11 +273,6 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 	return strings.Join(wrappedLines, "\r\n"), links
 }
 
-func stripANSI(s string) string {
-	re := regexp.MustCompile(ansiRegex)
-	return re.ReplaceAllString(s, "")
-}
-
 // RenderGemini converts text/gemini into a cview displayable format.
 // It also returns a slice of link URLs.
 //
@@ -292,7 +286,7 @@ func RenderGemini(s string, width, leftMargin int, proxied bool) (string, []stri
 	if viper.GetBool("a-general.color") && viper.GetBool("a-general.ansi") {
 		s = cview.TranslateANSI(s)
 	} else {
-		s = stripANSI(s)
+		s = ansiRegex.ReplaceAllString(s, "")
 	}
 
 	lines := strings.Split(s, "\n")

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -16,12 +16,18 @@ import (
 	"gitlab.com/tslocum/cview"
 )
 
+// Regex for identifying ANSI codes; credit to pkg acarl005/stripansi
+//nolint:lll
+const ansiRegex = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
 // RenderANSI renders plain text pages containing ANSI codes.
 // Practically, it is used for the text/x-ansi.
 func RenderANSI(s string, leftMargin int) string {
 	s = cview.Escape(s)
-	if viper.GetBool("a-general.color") {
+	if viper.GetBool("a-general.color") && viper.GetBool("a-general.ansi") {
 		s = cview.TranslateANSI(s)
+	} else {
+		s = stripANSI(s)
 	}
 	var shifted string
 	lines := strings.Split(s, "\n")
@@ -269,10 +275,7 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 }
 
 func stripANSI(s string) string {
-	ansi := "[\u001B\u009B][[\\]()#;?]*" +
-		"(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|" +
-		"(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
-	re := regexp.MustCompile(ansi)
+	re := regexp.MustCompile(ansiRegex)
 	return re.ReplaceAllString(s, "")
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -7,6 +7,7 @@ package renderer
 import (
 	"fmt"
 	urlPkg "net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -267,6 +268,11 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 	return strings.Join(wrappedLines, "\r\n"), links
 }
 
+func stripANSI(s string) (string) {
+	re := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
+	return re.ReplaceAllString(s, "")
+}
+
 // RenderGemini converts text/gemini into a cview displayable format.
 // It also returns a slice of link URLs.
 //
@@ -277,9 +283,12 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 // If it's not a gemini:// page, set this to true.
 func RenderGemini(s string, width, leftMargin int, proxied bool) (string, []string) {
 	s = cview.Escape(s)
-	if viper.GetBool("a-general.color") {
+	if viper.GetBool("a-general.color") && viper.GetBool("a-general.ansi") {
 		s = cview.TranslateANSI(s)
+	} else {
+		s = stripANSI(s)
 	}
+
 	lines := strings.Split(s, "\n")
 
 	links := make([]string, 0)

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -269,7 +269,10 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 }
 
 func stripANSI(s string) string {
-	re := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
+	ansi := "[\u001B\u009B][[\\]()#;?]*" +
+		"(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|" +
+		"(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+	re := regexp.MustCompile(ansi)
 	return re.ReplaceAllString(s, "")
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -268,7 +268,7 @@ func convertRegularGemini(s string, numLinks, width int, proxied bool) (string, 
 	return strings.Join(wrappedLines, "\r\n"), links
 }
 
-func stripANSI(s string) (string) {
+func stripANSI(s string) string {
 	re := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
 	return re.ReplaceAllString(s, "")
 }


### PR DESCRIPTION
Adds new boolean config option `ansi` in `[a-general]` to switch whether ANSI codes in page content will be rendered to terminal.

If `ansi `is set to false or `color` is set to false, any ANSI codes will be stripped from fetched content.
Fixes #79 

Here is a summary of results for the various values of the two options:

| config: color | config: ansi | Result                                    |
|---------------|--------------|-------------------------------------------|
| true          | true         | colorize headings & links; translate ANSI |
| true          | false        | colorize headings & links; strip ANSI     |
| false         | true         | no color; strip ANSI                      |
| false         | false        | no color; strip ANSI                      |

Notice how it is not possible to have `ansi` color codes true and `color` false at the same time. If the `color` config option is false, it overrides the value of `ansi`.

Feature to only allow ansi codes in preformatted blocks is part of another issue (#59)
