### PR TITLE
Add 'e' keybinding feature to edit current URL

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -295,6 +295,12 @@ func Init() {
 					// Don't save bottom bar, so that whenever you switch tabs, it's not in that mode
 					App.SetFocus(bottomBar)
 					return nil
+				case "e":
+					// Letter e allows to edit current URL
+					bottomBar.SetLabel("[::b]Edit URL: [::-]")
+					bottomBar.SetText(tabs[curTab].page.URL)
+					App.SetFocus(bottomBar)
+					return nil
 				case "R":
 					Reload()
 					return nil

--- a/display/help.go
+++ b/display/help.go
@@ -25,6 +25,7 @@ spacebar|Open bar at the bottom - type a URL, link number, search term.
 |Typing new:N will open link number N in a new tab
 |instead of the current one.
 Numbers|Go to links 1-10 respectively.
+e|Edit current URL
 Enter, Tab|On a page this will start link highlighting.
 |Press Tab and Shift-Tab to pick different links.
 |Press Enter again to go to one, or Esc to stop.


### PR DESCRIPTION
One thing I found myself wanting to do from time to time is make a slight tweak to the URL I am currently viewing.

I added this feature to edit the URL of the current page. Press 'e' to have the bottomBar populate with the current URL in case you want to change the path or query param. It is a good way to go to a similar path or page based on the existing URL without having to type the whole thing out again.