### PR TITLE
Implement a more robust algorithm for opening web links on unices

### DIFF
--- a/webbrowser/open_browser_darwin.go
+++ b/webbrowser/open_browser_darwin.go
@@ -4,6 +4,7 @@ package webbrowser
 
 import "os/exec"
 
+// Open opens `url` in default system browser.
 func Open(url string) (string, error) {
 	err := exec.Command("open", url).Start()
 	if err != nil {

--- a/webbrowser/open_browser_other.go
+++ b/webbrowser/open_browser_other.go
@@ -4,6 +4,7 @@ package webbrowser
 
 import "fmt"
 
+// Open opens `url` in default system browser, but not on this OS.
 func Open(url string) (string, error) {
 	return "", fmt.Errorf("unsupported OS for default HTTP handling. Set a command in the config")
 }

--- a/webbrowser/open_browser_unix.go
+++ b/webbrowser/open_browser_unix.go
@@ -9,27 +9,35 @@ import (
 	"os/exec"
 )
 
-// OpenInBrowser checks for the presence of a display server
-// and environment variables indicating a gui is present. If found
-// then xdg-open is called on a url to open said url in the default
-// gui web browser for the system
+// Open opens `url` in default system browser. It tries to do so in two
+// ways (xdg-open and $BROWSER). It only works if there is a display
+// server working.
+//
+// bouncepaw: I tried to support TTYs as well. The idea was to open
+// a browser in foreground and return back to amfora after the browser
+// is closed. While all browsers I tested opened correctly (w3m, lynx),
+// I couldn't make it restore amfora correctly. The screen always ended
+// up distorted. None of my stunts with altscreen buffers helped.
 func Open(url string) (string, error) {
-	disp := os.Getenv("DISPLAY")
-	wayland := os.Getenv("WAYLAND_DISPLAY")
-	_, err := exec.LookPath("Xorg")
-	if disp == "" && wayland == "" && err != nil {
+	var (
+		// In prev versions there was also Xorg executable checked for.
+		// I don't see any reason to check for it.
+		xorgDisplay                     = os.Getenv("DISPLAY")
+		waylandDisplay                  = os.Getenv("WAYLAND_DISPLAY")
+		xdgOpenPath, xdgOpenNotFoundErr = exec.LookPath("xdg-open")
+		envBrowser                      = os.Getenv("BROWSER")
+	)
+	switch {
+	case xorgDisplay == "" && waylandDisplay == "":
 		return "", fmt.Errorf("no gui is available")
+	case xdgOpenNotFoundErr == nil || envBrowser != "":
+		// Use start rather than run or output in order
+		// to make browser running in background.
+		if err := exec.Command(xdgOpenPath, url).Start(); err != nil {
+			return "", err
+		}
+		return "Opened in system default web browser", nil
+	default:
+		return "", fmt.Errorf("could not determine system browser")
 	}
-
-	_, err = exec.LookPath("xdg-open")
-	if err != nil {
-		return "", fmt.Errorf("xdg-open command not found, cannot open in web browser")
-	}
-	// Use start rather than run or output in order
-	// to release the process and not block
-	err = exec.Command("xdg-open", url).Start()
-	if err != nil {
-		return "", err
-	}
-	return "Opened in system default web browser", nil
 }

--- a/webbrowser/open_browser_unix.go
+++ b/webbrowser/open_browser_unix.go
@@ -29,7 +29,7 @@ func Open(url string) (string, error) {
 	)
 	switch {
 	case xorgDisplay == "" && waylandDisplay == "":
-		return "", fmt.Errorf("no gui is available")
+		return "", fmt.Errorf("no display server was found")
 	case xdgOpenNotFoundErr == nil || envBrowser != "":
 		// Use start rather than run or output in order
 		// to make browser running in background.

--- a/webbrowser/open_browser_unix.go
+++ b/webbrowser/open_browser_unix.go
@@ -38,7 +38,7 @@ func Open(url string) (string, error) {
 		}
 		return "Opened in system default web browser", nil
 	case envBrowser != "":
-		if err := exec.Command(xdgOpenPath, url).Start(); err != nil {
+		if err := exec.Command(envBrowser, url).Start(); err != nil {
 			return "", err
 		}
 		return "Opened in system default web browser", nil

--- a/webbrowser/open_browser_unix.go
+++ b/webbrowser/open_browser_unix.go
@@ -30,9 +30,14 @@ func Open(url string) (string, error) {
 	switch {
 	case xorgDisplay == "" && waylandDisplay == "":
 		return "", fmt.Errorf("no display server was found")
-	case xdgOpenNotFoundErr == nil || envBrowser != "":
+	case xdgOpenNotFoundErr == nil: // Prefer xdg-open over $BROWSER
 		// Use start rather than run or output in order
 		// to make browser running in background.
+		if err := exec.Command(xdgOpenPath, url).Start(); err != nil {
+			return "", err
+		}
+		return "Opened in system default web browser", nil
+	case envBrowser != "":
 		if err := exec.Command(xdgOpenPath, url).Start(); err != nil {
 			return "", err
 		}

--- a/webbrowser/open_browser_windows.go
+++ b/webbrowser/open_browser_windows.go
@@ -5,6 +5,7 @@ package webbrowser
 
 import "os/exec"
 
+// Open opens `url` in default system browser.
 func Open(url string) (string, error) {
 	err := exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
 	if err != nil {


### PR DESCRIPTION
## Changes
* `webbrowser.Open` now tries to use `$BROWSER` env variable before giving up if there is no `xdg-open` installed.
* Do not check for `Xorg` program anymore. I think it is safe to expect that there is X installed if `$DISPLAY` is set.
* Add some comments.

## TTY browsers
As a comment in this PR mentions, I couldn't implement it. Something goes wrong when trying to restore `amfora` after closing a terminal browser (running in foreground, of course). If anyone wishes to implement it, they could check this:
* [termenv's screen.go](https://github.com/muesli/termenv/blob/master/screen.go) for altscreen sequences
* [this SO answer](https://stackoverflow.com/questions/21513321/how-to-start-vim-from-go) for information on how to launch ncurses programs