### PR TITLE
Remove protocol filter for bookmarking

### DIFF
--- a/display/bookmarks.go
+++ b/display/bookmarks.go
@@ -3,7 +3,6 @@ package display
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/gdamore/tcell"
 	"github.com/makeworld-the-better-one/amfora/bookmarks"
@@ -135,10 +134,6 @@ func Bookmarks(t *tab) {
 // It is the high-level way of doing it. It should be called in a goroutine.
 // It can also be called to edit an existing bookmark.
 func addBookmark() {
-	if !strings.HasPrefix(tabs[curTab].page.URL, "gemini://") {
-		// Can't make bookmarks for other kinds of URLs
-		return
-	}
 	curPage := tabs[curTab].page
 	name, exists := bookmarks.Get(curPage.URL)
 	// Open a bookmark modal with the current name of the bookmark, if it exists


### PR DESCRIPTION
Apologies if I've missed some nuance that this breaks, but I figured it was more helpful to post a PR than an issue here.

This removes the protocol filter when adding a bookmark. I've been using amfora along with solderpunk's `agena` proxy (https://tildegit.org/solderpunk/agena) for accessing gopher, and it works beautifully well.

With this patch, adding and visiting bookmarks works just fine.

I'm happy to do further testing with my setup if necessary.