### PR TITLE
Remove basedir check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,12 +62,7 @@ func Init() error {
 		configDir = amforaAppData
 	} else {
 		// Unix / POSIX system
-		if basedir.ConfigHome == "" {
-			// Default to ~/.config/amfora
-			configDir = filepath.Join(home, ".config", "amfora")
-		} else {
-			configDir = filepath.Join(basedir.ConfigHome, "amfora")
-		}
+		configDir = filepath.Join(basedir.ConfigHome, "amfora")
 	}
 	configPath = filepath.Join(configDir, "config.toml")
 
@@ -84,12 +79,7 @@ func Init() error {
 		tofuDBDir = amforaAppData
 	} else {
 		// XDG cache dir on POSIX systems
-		if basedir.CacheHome == "" {
-			// Default to ~/.cache/amfora
-			tofuDBDir = filepath.Join(home, ".cache", "amfora")
-		} else {
-			tofuDBDir = filepath.Join(basedir.CacheHome, "amfora")
-		}
+		tofuDBDir = filepath.Join(basedir.CacheHome, "amfora")
 	}
 	tofuDBPath = filepath.Join(tofuDBDir, "tofu.toml")
 
@@ -99,12 +89,7 @@ func Init() error {
 		bkmkDir = amforaAppData
 	} else {
 		// XDG data dir on POSIX systems
-		if basedir.DataHome == "" {
-			// Default to ~/.local/share/amfora
-			bkmkDir = filepath.Join(home, ".local", "share", "amfora")
-		} else {
-			bkmkDir = filepath.Join(basedir.DataHome, "amfora")
-		}
+		bkmkDir = filepath.Join(basedir.DataHome, "amfora")
 	}
 	bkmkPath = filepath.Join(bkmkDir, "bookmarks.toml")
 


### PR DESCRIPTION
Basedir checks are not needed as it is set by default. See: https://github.com/rkoesters/xdg/blob/master/basedir/basedir.go#L52-L66