### PR TITLE
Allow using terminal default background as color

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -230,7 +230,7 @@ func Init() error {
 				return fmt.Errorf(`value for "%s" is not a string: %v`, k, v)
 			}
 			color := tcell.GetColor(strings.ToLower(colorStr))
-			if color == tcell.ColorDefault && colorStr != "default" {
+			if color == tcell.ColorDefault && !(colorStr == "defaultbg" && k == "bg") {
 				return fmt.Errorf(`invalid color format for "%s": %s`, k, colorStr)
 
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -230,8 +230,9 @@ func Init() error {
 				return fmt.Errorf(`value for "%s" is not a string: %v`, k, v)
 			}
 			color := tcell.GetColor(strings.ToLower(colorStr))
-			if color == tcell.ColorDefault {
+			if color == tcell.ColorDefault && colorStr != "default" {
 				return fmt.Errorf(`invalid color format for "%s": %s`, k, colorStr)
+
 			}
 			SetColor(k, color)
 		}

--- a/config/default.go
+++ b/config/default.go
@@ -153,6 +153,10 @@ max_pages = 30 # The maximum number of pages the cache will store
 # EXAMPLES:
 # hdg_1 = "green"
 # hdg_2 = "#5f0000"
+# bg = "defaultbg"
+
+# A special value for bg is avaliable: "defaultbg"
+# This is for keeping your default terminal background or transparency.
 
 # Available keys to set:
 

--- a/config/default.go
+++ b/config/default.go
@@ -155,7 +155,7 @@ max_pages = 30 # The maximum number of pages the cache will store
 # hdg_2 = "#5f0000"
 # bg = "defaultbg"
 
-# A special value for bg is avaliable: "defaultbg"
+# A special value for bg is available: "defaultbg"
 # This is for keeping your default terminal background or transparency.
 
 # Available keys to set:

--- a/default-config.toml
+++ b/default-config.toml
@@ -152,7 +152,7 @@ max_pages = 30 # The maximum number of pages the cache will store
 # hdg_2 = "#5f0000"
 # bg = "defaultbg"
 
-# A special value for bg is avaliable: "defaultbg"
+# A special value for bg is available: "defaultbg"
 # This is for keeping your default terminal background or transparency.
 
 # Available keys to set:

--- a/default-config.toml
+++ b/default-config.toml
@@ -150,6 +150,10 @@ max_pages = 30 # The maximum number of pages the cache will store
 # EXAMPLES:
 # hdg_1 = "green"
 # hdg_2 = "#5f0000"
+# bg = "defaultbg"
+
+# A special value for bg is avaliable: "defaultbg"
+# This is for keeping your default terminal background or transparency.
 
 # Available keys to set:
 


### PR DESCRIPTION
Sometimes this is desirable. For example using terminal default background (or transparent terminal) instead of filling with black comes to mind.