### PR TITLE
fix for #103: Simple handling of local (file://) urls

### DIFF
--- a/display/file.go
+++ b/display/file.go
@@ -76,6 +76,7 @@ func handleFile(u string) (*structs.Page, bool) {
 				Raw:       content,
 				Content:   rendered,
 				Links:     links,
+				Width:     termW,
 			}
 		} else {
 			page = &structs.Page{
@@ -84,6 +85,7 @@ func handleFile(u string) (*structs.Page, bool) {
 				Raw:       content,
 				Content:   renderer.RenderPlainText(content, leftMargin()),
 				Links:     []string{},
+				Width:     termW,
 			}
 		}
 	}
@@ -117,6 +119,7 @@ func createDirectoryListing(u string) (*structs.Page, bool) {
 		Raw:       content,
 		Content:   rendered,
 		Links:     links,
+		Width:     termW,
 	}
 	return page, true
 }

--- a/display/file.go
+++ b/display/file.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"unicode/utf8"
-	"path/filepath"
 
 	"github.com/makeworld-the-better-one/amfora/renderer"
 	"github.com/makeworld-the-better-one/amfora/structs"

--- a/display/file.go
+++ b/display/file.go
@@ -16,7 +16,7 @@ import (
 func pathFromURI(u string) string {
 	path := strings.TrimPrefix(u, "file://")
 	path = strings.TrimPrefix(path, "localhost") // localhost is a valid host for file URIs
-	path = strings.TrimPrefix(path, "/") // Valid file URIs contains this additional slash
+	path = strings.TrimPrefix(path, "/")         // Valid file URIs contains this additional slash
 	return filepath.FromSlash(path)
 }
 

--- a/display/file.go
+++ b/display/file.go
@@ -22,7 +22,7 @@ func handleFile(u string) (*structs.Page, bool) {
 
 	fi, err := os.Stat(filename)
 	if err != nil {
-		Error("Cannot open local file", err.Error())
+		Error("File Error", "Cannot open local file: "+err.Error())
 		return page, false
 	}
 
@@ -31,13 +31,13 @@ func handleFile(u string) (*structs.Page, bool) {
 		return createDirectoryListing(u)
 	case mode.IsRegular():
 		if fi.Size() > viper.GetInt64("a-general.page_max_size") {
-			Error("Cannot open local file", "Too large.")
+			Error("File Error", "Cannot open local file, exceeds page max size")
 			return page, false
 		}
 
 		file, err := os.Open(filename)
 		if err != nil {
-			Error("Cannot open local file", err.Error())
+			Error("File Error", "Cannot open local file: "+err.Error())
 			return page, false
 		}
 		defer file.Close()
@@ -46,12 +46,12 @@ func handleFile(u string) (*structs.Page, bool) {
 		buf := make([]byte, 32)
 		_, err = file.Read(buf)
 		if err != nil && err != io.EOF {
-			Error("Error reading file", err.Error())
+			Error("File Error", "Error reading file: "+err.Error())
 			return page, false
 		}
 
 		if !utf8.Valid(buf) {
-			Error("Cannot open local file", "Looks like a binary.")
+			Error("File Error", "Cannot open local file, looks like a binary.")
 			return page, false
 		}
 
@@ -61,7 +61,7 @@ func handleFile(u string) (*structs.Page, bool) {
 			_, err := file.Read(buf)
 			if err != nil {
 				if err != io.EOF {
-					Error("Error reading file", err.Error())
+					Error("File Error", "Cannot open local file: "+err.Error())
 					return page, false
 				}
 				break
@@ -97,7 +97,7 @@ func createDirectoryListing(u string) (*structs.Page, bool) {
 	filename := filepath.FromSlash(strings.TrimPrefix(u, "file://"))
 	files, err := ioutil.ReadDir(filename)
 	if err != nil {
-		Error("Cannot open local directory", err.Error())
+		Error("Directory error", "Cannot open local directory: "+err.Error())
 		return page, false
 	}
 	content := "Index of " + filename + "\n"

--- a/display/file.go
+++ b/display/file.go
@@ -1,0 +1,129 @@
+package display
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/makeworld-the-better-one/amfora/renderer"
+	"github.com/makeworld-the-better-one/amfora/structs"
+)
+
+const maxSize = 1 * 1024 * 1024 // 1 Mb
+
+// handleFile handles urls using file:// protocol
+func handleFile(u string) (*structs.Page, bool) {
+	page := &structs.Page{}
+
+	filename := strings.TrimPrefix(u, "file://")
+
+	fi, err := os.Stat(filename)
+	if err != nil {
+		Error("Cannot open local file", err.Error())
+		return page, false
+	}
+
+	switch mode := fi.Mode(); {
+	case mode.IsDir():
+		return createDirectoryListing(u)
+	case mode.IsRegular():
+
+		if fi.Size() > maxSize {
+			Error("Cannot open local file", "Too large.")
+			return page, false
+		}
+
+		file, err := os.Open(filename)
+		if err != nil {
+			Error("Cannot open local file", err.Error())
+			return page, false
+		}
+		defer file.Close()
+
+		// Read first bytes, to check if plaintext
+		buf := make([]byte, 32)
+		_, err = file.Read(buf)
+
+		if !utf8.Valid(buf) {
+			Error("Cannot open local file", "Looks like a binary.")
+			return page, false
+		}
+
+		// Looks like plaintext, keep reading
+		content := string(buf)
+		for {
+			_, err := file.Read(buf)
+			if err != nil {
+				if err != io.EOF {
+					Error("Error reading file", err.Error())
+					return page, false
+				}
+				break
+			}
+			content += string(buf)
+		}
+		if strings.HasSuffix(u, ".gmi") || strings.HasSuffix(u, ".gemini") {
+			rendered, links := renderer.RenderGemini(content, textWidth(), leftMargin(), false)
+			page = &structs.Page{
+				Mediatype: structs.TextGemini,
+				URL:       u,
+				Raw:       content,
+				Content:   rendered,
+				Links:     links,
+			}
+		} else {
+			page = &structs.Page{
+				Mediatype: structs.TextPlain,
+				URL:       u,
+				Raw:       content,
+				Content:   renderer.RenderPlainText(content, leftMargin()),
+				Links:     []string{},
+			}
+		}
+	}
+	return page, true
+}
+
+// createDirectoryListing creates a text/gemini page for a directory
+// that lists all the files as links.
+func createDirectoryListing(u string) (*structs.Page, bool) {
+	page := &structs.Page{}
+	filename := strings.TrimPrefix(u, "file://")
+	files, err := ioutil.ReadDir(filename)
+	if err != nil {
+		Error("Cannot open local directory", err.Error())
+		return page, false
+	}
+	content := "Index of " + filename + "/\n"
+	content += "=> .. ../\n"
+	for _, f := range files {
+		separator := ""
+		if f.IsDir() {
+			separator = "/"
+		}
+		content += fmt.Sprintf("=> %s %s%s\n", f.Name(), f.Name(), separator)
+	}
+
+	rendered, links := renderer.RenderGemini(content, textWidth(), leftMargin(), false)
+	page = &structs.Page{
+
+		Mediatype: structs.TextGemini,
+		URL:       u,
+		Raw:       content,
+		Content:   rendered,
+		Links:     links,
+	}
+	return page, true
+}
+
+// resolveRelFileLink constructs a relative file:// link by keeping path
+// from previous url
+func resolveRelFileLink(t *tab, prev, next string) string {
+	if !t.hasContent() || strings.Contains(next, "://") {
+		return next
+	}
+	return prev[:strings.LastIndex(prev, "/")] + "/" + next
+}

--- a/display/file.go
+++ b/display/file.go
@@ -31,7 +31,6 @@ func handleFile(u string) (*structs.Page, bool) {
 	case mode.IsDir():
 		return createDirectoryListing(u)
 	case mode.IsRegular():
-
 		if fi.Size() > maxSize {
 			Error("Cannot open local file", "Too large.")
 			return page, false
@@ -114,7 +113,6 @@ func createDirectoryListing(u string) (*structs.Page, bool) {
 
 	rendered, links := renderer.RenderGemini(content, textWidth(), leftMargin(), false)
 	page = &structs.Page{
-
 		Mediatype: structs.TextGemini,
 		URL:       u,
 		Raw:       content,

--- a/display/file.go
+++ b/display/file.go
@@ -11,9 +11,8 @@ import (
 
 	"github.com/makeworld-the-better-one/amfora/renderer"
 	"github.com/makeworld-the-better-one/amfora/structs"
+	"github.com/spf13/viper"
 )
-
-const maxSize = 1 * 1024 * 1024 // 1 Mb
 
 // handleFile handles urls using file:// protocol
 func handleFile(u string) (*structs.Page, bool) {
@@ -31,7 +30,7 @@ func handleFile(u string) (*structs.Page, bool) {
 	case mode.IsDir():
 		return createDirectoryListing(u)
 	case mode.IsRegular():
-		if fi.Size() > maxSize {
+		if fi.Size() > viper.GetInt64("a-general.page_max_size") {
 			Error("Cannot open local file", "Too large.")
 			return page, false
 		}

--- a/display/file.go
+++ b/display/file.go
@@ -123,8 +123,8 @@ func createDirectoryListing(u string) (*structs.Page, bool) {
 	return page, true
 }
 
-// resolveRelFileLink constructs a relative file:// link by keeping path
-// from previous url
+// resolveRelFileLink constructs a relative file:// link by matching it against
+// previous url
 func resolveRelFileLink(t *tab, prev, next string) string {
 	if !t.hasContent() || strings.Contains(next, "://") {
 		return next

--- a/display/file.go
+++ b/display/file.go
@@ -101,14 +101,14 @@ func createDirectoryListing(u string) (*structs.Page, bool) {
 		Error("Cannot open local directory", err.Error())
 		return page, false
 	}
-	content := "Index of " + filename + "/\n"
-	content += "=> .. ../\n"
+	content := "Index of " + filename + "\n"
+	content += "=> ../ ../\n"
 	for _, f := range files {
 		separator := ""
 		if f.IsDir() {
 			separator = "/"
 		}
-		content += fmt.Sprintf("=> %s %s%s\n", f.Name(), f.Name(), separator)
+		content += fmt.Sprintf("=> %s%s %s%s\n", f.Name(), separator, f.Name(), separator)
 	}
 
 	rendered, links := renderer.RenderGemini(content, textWidth(), leftMargin(), false)

--- a/display/file.go
+++ b/display/file.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"unicode/utf8"
+	"path/filepath"
 
 	"github.com/makeworld-the-better-one/amfora/renderer"
 	"github.com/makeworld-the-better-one/amfora/structs"
@@ -18,7 +19,7 @@ const maxSize = 1 * 1024 * 1024 // 1 Mb
 func handleFile(u string) (*structs.Page, bool) {
 	page := &structs.Page{}
 
-	filename := strings.TrimPrefix(u, "file://")
+	filename := filepath.FromSlash(strings.TrimPrefix(u, "file://"))
 
 	fi, err := os.Stat(filename)
 	if err != nil {
@@ -95,7 +96,7 @@ func handleFile(u string) (*structs.Page, bool) {
 // that lists all the files as links.
 func createDirectoryListing(u string) (*structs.Page, bool) {
 	page := &structs.Page{}
-	filename := strings.TrimPrefix(u, "file://")
+	filename := filepath.FromSlash(strings.TrimPrefix(u, "file://"))
 	files, err := ioutil.ReadDir(filename)
 	if err != nil {
 		Error("Cannot open local directory", err.Error())

--- a/display/file.go
+++ b/display/file.go
@@ -46,7 +46,7 @@ func handleFile(u string) (*structs.Page, bool) {
 		// Read first bytes, to check if plaintext
 		buf := make([]byte, 32)
 		_, err = file.Read(buf)
-		if err != io.EOF {
+		if err != nil && err != io.EOF {
 			Error("Error reading file", err.Error())
 			return page, false
 		}

--- a/display/file.go
+++ b/display/file.go
@@ -45,7 +45,7 @@ func handleFile(u string) (*structs.Page, bool) {
 		}
 
 		if !strings.HasPrefix(mimetype, "text/") {
-			Error("File Error", "Cannot open file, unknown mimetype.")
+			Error("File Error", "Cannot open file, not recognized as text.")
 			return page, false
 		}
 

--- a/display/file.go
+++ b/display/file.go
@@ -120,12 +120,3 @@ func createDirectoryListing(u string) (*structs.Page, bool) {
 	}
 	return page, true
 }
-
-// resolveRelFileLink constructs a relative file:// link by matching it against
-// previous url
-func resolveRelFileLink(t *tab, prev, next string) string {
-	if !t.hasContent() || strings.Contains(next, "://") {
-		return next
-	}
-	return prev[:strings.LastIndex(prev, "/")] + "/" + next
-}

--- a/display/file.go
+++ b/display/file.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func pathFromURI(u string) string {
+func pathFromFileURI(u string) string {
 	path := strings.TrimPrefix(u, "file://")
 	path = strings.TrimPrefix(path, "localhost") // localhost is a valid host for file URIs
 	path = strings.TrimPrefix(path, "/")         // Valid file URIs contains this additional slash
@@ -23,7 +23,7 @@ func pathFromURI(u string) string {
 // handleFile handles urls using file:// protocol
 func handleFile(u string) (*structs.Page, bool) {
 	page := &structs.Page{}
-	path := pathFromURI(u)
+	path := pathFromFileURI(u)
 	fi, err := os.Stat(path)
 	if err != nil {
 		Error("File Error", "Cannot open local file: "+err.Error())
@@ -84,7 +84,7 @@ func handleFile(u string) (*structs.Page, bool) {
 // that lists all the files as links.
 func createDirectoryListing(u string) (*structs.Page, bool) {
 	page := &structs.Page{}
-	path := pathFromURI(u)
+	path := pathFromFileURI(u)
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		Error("Directory error", "Cannot open local directory: "+err.Error())

--- a/display/file.go
+++ b/display/file.go
@@ -46,6 +46,10 @@ func handleFile(u string) (*structs.Page, bool) {
 		// Read first bytes, to check if plaintext
 		buf := make([]byte, 32)
 		_, err = file.Read(buf)
+		if err != io.EOF {
+			Error("Error reading file", err.Error())
+			return page, false
+		}
 
 		if !utf8.Valid(buf) {
 			Error("Cannot open local file", "Looks like a binary.")

--- a/display/private.go
+++ b/display/private.go
@@ -43,9 +43,7 @@ func followLink(t *tab, prev, next string) {
 
 	if t.hasContent() {
 		t.saveScroll() // Likely called later on, it's here just in case
-		var nextURL string
-		var err error
-		nextURL, err = resolveRelLink(t, prev, next)
+		nextURL, err := resolveRelLink(t, prev, next)
 		if err != nil {
 			Error("URL Error", err.Error())
 			return

--- a/display/private.go
+++ b/display/private.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -188,66 +186,6 @@ func handleHTTP(u string, showInfo bool) bool {
 
 	App.Draw()
 	return true
-}
-
-func handleFile(u string) (*structs.Page, bool) {
-
-	page := &structs.Page{}
-
-	file := strings.TrimPrefix(u, "file://")
-
-	fi, err := os.Stat(file)
-	if err != nil {
-		Error("Cannot open local file", err.Error())
-		return page, false
-	}
-
-	switch mode := fi.Mode(); {
-	case mode.IsDir():
-		content := "Index of " + file + "/\n"
-
-		files, err := ioutil.ReadDir(file)
-		if err != nil {
-			Error("Cannot open local directory", err.Error())
-			return page, false
-		}
-
-		for _, f := range files {
-			content += fmt.Sprintf("=> %s %s\n", f.Name(), f.Name())
-		}
-
-		rendered, links := renderer.RenderGemini(content, textWidth(), leftMargin(), false)
-		page = &structs.Page{
-			Mediatype: structs.TextGemini,
-			URL:       u,
-			Raw:       content,
-			Content:   rendered,
-			Links:     links,
-		}
-
-	case mode.IsRegular():
-
-		if !strings.HasSuffix(u, ".gmi") && !strings.HasSuffix(u, ".gemini") {
-			Error("Unsupported filetype", "Try opening a .gmi or .gemini file.")
-			return page, false
-		}
-
-		content, err := ioutil.ReadFile(file)
-		if err != nil {
-			Error("Cannot open local file", err.Error())
-			return page, false
-		}
-		rendered, links := renderer.RenderGemini(string(content), textWidth(), leftMargin(), false)
-		page = &structs.Page{
-			Mediatype: structs.TextGemini,
-			URL:       u,
-			Raw:       string(content),
-			Content:   rendered,
-			Links:     links,
-		}
-	}
-
-	return page, true
 }
 
 // handleOther is used by handleURL.

--- a/display/private.go
+++ b/display/private.go
@@ -379,12 +379,10 @@ func handleURL(t *tab, u string, numRedirects int) (string, bool) {
 	}
 
 	if strings.HasPrefix(u, "file") {
-
 		page, ok := handleFile(u)
 		if !ok {
 			return ret("", false)
 		}
-
 		setPage(t, page)
 		return ret(u, true)
 	}

--- a/display/private.go
+++ b/display/private.go
@@ -44,15 +44,11 @@ func followLink(t *tab, prev, next string) {
 	if t.hasContent() {
 		t.saveScroll() // Likely called later on, it's here just in case
 		var nextURL string
-		if strings.HasPrefix(prev, "file") {
-			nextURL = resolveRelFileLink(t, prev, next)
-		} else {
-			var err error
-			nextURL, err = resolveRelLink(t, prev, next)
-			if err != nil {
-				Error("URL Error", err.Error())
-				return
-			}
+		var err error
+		nextURL, err = resolveRelLink(t, prev, next)
+		if err != nil {
+			Error("URL Error", err.Error())
+			return
 		}
 		go goURL(t, nextURL)
 		return

--- a/display/private.go
+++ b/display/private.go
@@ -84,7 +84,9 @@ func reformatPage(p *structs.Page) {
 	case structs.TextGemini:
 		// Links are not recorded because they won't change
 		proxied := true
-		if strings.HasPrefix(p.URL, "gemini") || strings.HasPrefix(p.URL, "about") {
+		if strings.HasPrefix(p.URL, "gemini") ||
+			strings.HasPrefix(p.URL, "about") ||
+			strings.HasPrefix(p.URL, "file") {
 			proxied = false
 		}
 		rendered, _ = renderer.RenderGemini(p.Raw, textWidth(), leftMargin(), proxied)

--- a/display/util.go
+++ b/display/util.go
@@ -65,6 +65,15 @@ func resolveRelLink(t *tab, prev, next string) (string, error) {
 		return "", errors.New("link URL could not be parsed") //nolint:goerr113
 	}
 	return prevParsed.ResolveReference(nextParsed).String(), nil
+
+}
+
+// TODO: Document
+func resolveRelFileLink(t *tab, prev, next string) string {
+	if !t.hasContent() || strings.Contains(next, "://") {
+		return next
+	}
+	return prev[:strings.LastIndex(prev, "/")] + "/" + next
 }
 
 // normalizeURL attempts to make URLs that are different strings

--- a/display/util.go
+++ b/display/util.go
@@ -68,14 +68,6 @@ func resolveRelLink(t *tab, prev, next string) (string, error) {
 
 }
 
-// TODO: Document
-func resolveRelFileLink(t *tab, prev, next string) string {
-	if !t.hasContent() || strings.Contains(next, "://") {
-		return next
-	}
-	return prev[:strings.LastIndex(prev, "/")] + "/" + next
-}
-
 // normalizeURL attempts to make URLs that are different strings
 // but point to the same place all look the same.
 //

--- a/display/util.go
+++ b/display/util.go
@@ -65,7 +65,6 @@ func resolveRelLink(t *tab, prev, next string) (string, error) {
 		return "", errors.New("link URL could not be parsed") //nolint:goerr113
 	}
 	return prevParsed.ResolveReference(nextParsed).String(), nil
-
 }
 
 // normalizeURL attempts to make URLs that are different strings


### PR DESCRIPTION
Simple implementation for rendering local (file://) documents.

When opening a `file://` url:
**If it is a directory:**
Render a page with links to all dirs and files in directory.
Links are made to all kinds of files, checking if reasonable to open is done when actually opening them (with error popups)

**If it is a file:**
- If not a gemini file, use mime.TypeByExtension to check if text/* otherwise bail
- render .gemini/.gmi as gemini
- else render as plaintext

# TODO
- [x] directory listing
- [x] Files
   - [x] prohibit binaries
   - [x] gemini files
   - [x] other plain text files
- [x] links to other local resources
- [x] links to non-file://urls works as usual
- [x] Test on Linux
- [x] Test on Windows

fixes #103 