### PR TITLE
Mediatypes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Features in *italics* are in the master branch, but not in the latest release.
   - Disabled by default, enable in config
 - [x] Proxying
   - Schemes like Gopher or HTTP can be proxied through a Gemini server
+- [x] Configure applications to open particular mediatypes
+    - [ ] Allow piping/streaming content instead of downloading it first.
 - [x] Client certificate support
   - [ ] Full client certificate UX within the client
     - Create transient and permanent certs within the client, per domain

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Features in *italics* are in the master branch, but not in the latest release.
   - Disabled by default, enable in config
 - [x] Proxying
   - Schemes like Gopher or HTTP can be proxied through a Gemini server
-- [x] Configure applications to open particular mediatypes
-    - [ ] Allow piping/streaming content instead of downloading it first.
+- [x] *Configure applications to open particular mediatypes*
+    - [ ] Allow piping/streaming content instead of downloading it first
 - [x] Client certificate support
   - [ ] Full client certificate UX within the client
     - Create transient and permanent certs within the client, per domain

--- a/config/config.go
+++ b/config/config.go
@@ -281,5 +281,20 @@ func Init() error {
 		HTTPCommand = strings.Fields(viper.GetString("a-general.http"))
 	}
 
+	// Make sure MIME commands are all in array form
+	for mime := range viper.GetStringMap("mime-handlers") {
+		key := "mime-handlers." + mime + ".command"
+		if viper.IsSet(key) {
+			cmd := viper.GetStringSlice(key)
+			if len(cmd) == 0 {
+				cmd = strings.Fields(viper.GetString(key))
+			}
+			if len(cmd) == 0 {
+				cmd = nil
+			}
+			viper.Set(key, cmd)
+		}
+	}
+
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -298,7 +298,7 @@ func Init() error {
 		key = "mime-handlers." + mime + ".action"
 		if viper.IsSet(key) {
 			action := strings.ToLower(viper.GetString(key))
-			switch (action) {
+			switch action {
 			case "prompt":
 			case "download":
 			case "open":

--- a/config/config.go
+++ b/config/config.go
@@ -281,7 +281,7 @@ func Init() error {
 		HTTPCommand = strings.Fields(viper.GetString("a-general.http"))
 	}
 
-	// Make sure MIME commands are all in array form
+	// Make sure MIME commands are all in array form and have valid actions
 	for mime := range viper.GetStringMap("mime-handlers") {
 		key := "mime-handlers." + mime + ".command"
 		if viper.IsSet(key) {
@@ -293,6 +293,21 @@ func Init() error {
 				cmd = nil
 			}
 			viper.Set(key, cmd)
+		}
+
+		key = "mime-handlers." + mime + ".action"
+		if viper.IsSet(key) {
+			action := strings.ToLower(viper.GetString(key))
+			switch (action) {
+			case "prompt":
+			case "download":
+			case "open":
+			case "":
+				action = "prompt"
+			default:
+				return fmt.Errorf(`invalid value for "%s": %s`, key, action)
+			}
+			viper.Set(key, action)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -184,7 +184,7 @@ func Init() error {
 		// Make sure it exists
 		err = os.MkdirAll(TempDownloadsDir, 0755)
 		if err != nil {
-			return fmt.Errorf("downloads path could not be created: %s", DownloadsDir)
+			return fmt.Errorf("temp downloads path could not be created: %s", TempDownloadsDir)
 		}
 	} else {
 		// Validate path
@@ -300,7 +300,7 @@ func Init() error {
 	for _, rawMediaHandler := range rawMediaHandlers {
 		for _, typ := range rawMediaHandler.Types {
 			if _, ok := MediaHandlers[typ]; ok {
-				return fmt.Errorf(`Multiple mediatype-handlers defined for %v`, typ)
+				return fmt.Errorf("multiple mediatype-handlers defined for %v", typ)
 			}
 			MediaHandlers[typ] = MediaHandler{
 				Cmd:      rawMediaHandler.Cmd,

--- a/config/config.go
+++ b/config/config.go
@@ -179,7 +179,7 @@ func Init() error {
 
 	// Setup temporary downloads dir
 	if viper.GetString("a-general.temp_downloads") == "" {
-		TempDownloadsDir = filepath.Join(os.TempDir(), "amfora-downloads")
+		TempDownloadsDir = filepath.Join(os.TempDir(), "amfora_temp")
 
 		// Make sure it exists
 		err = os.MkdirAll(TempDownloadsDir, 0755)
@@ -295,12 +295,12 @@ func Init() error {
 	}
 	err = viper.UnmarshalKey("mediatype-handlers", &rawMediaHandlers)
 	if err != nil {
-		return err
+		return fmt.Errorf("couldn't parse mediatype-handlers section in config: %w", err)
 	}
 	for _, rawMediaHandler := range rawMediaHandlers {
 		for _, typ := range rawMediaHandler.Types {
 			if _, ok := MediaHandlers[typ]; ok {
-				return fmt.Errorf(`Multiple midiatype-handlers defined for %v`, typ)
+				return fmt.Errorf(`Multiple mediatype-handlers defined for %v`, typ)
 			}
 			MediaHandlers[typ] = MediaHandler{
 				Cmd:      rawMediaHandler.Cmd,

--- a/config/default.go
+++ b/config/default.go
@@ -112,6 +112,54 @@ shift_numbers = "!@#$%^&*()"
 other = 'off'
 
 
+# [[mediatype-handlers]]
+# Specify what applications will open certain media types.
+# By default your default application will be used to open the file when you select "Open".
+# You only need to configure this section if you want to override your default application,
+# or do special things like streaming.
+#
+# To open jpeg files with the feh command:
+#   [[mediatype-handlers]]
+#   cmd = ["feh"]
+#   types = ["image/jpeg"]
+#
+# Each command that you specify must come under its own [[mediatype-handlers]]. You may
+# specify as many [[mediatype-handlers]] as you want to setup multiple commands.
+#
+# If the subtype is omitted then the specified command will be used for the
+# entire type:
+#   [[mediatype-handlers]]
+#   command = ["vlc", "--flag"]
+#   types = ["audio", "video"]
+#
+# A catch-all handler can by specified with "*".
+# Note that there are already catch-all handlers in place for all OSes,
+# that open the file using your default application. This is only if you
+# want to override that.
+#   [[mediatype-handlers]]
+#   cmd = ["some-command"]
+#   types = [
+#           "application/pdf",
+#           "*",
+#   ]
+#
+# If you want to always open a type in its viewer without the download or open
+# prompt appearing, you can add no_prompt = true
+#
+#   [[mediatype-handlers]]
+#   cmd = ["feh"]
+#   types = ["image"]
+#   no_prompt = true
+#
+# Note: Multiple handlers cannot be defined for the same full media type, but
+# still there needs to be an order for which handlers are used. The following
+# order applies regardless of the order written in the config:
+#
+# 1. Full media type: "image/jpeg"
+# 2. Just type: "image"
+# 3. Catch-all: "*"
+
+
 [cache]
 # Options for page cache - which is only for text/gemini pages
 # Increase the cache size to speed up browsing at the expense of memory

--- a/config/default.sh
+++ b/config/default.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-head -n 3 default.go | tee default.go > /dev/null
+cat > default.go <<-EOF
+package config
+
+//go:generate ./default.sh
+EOF
 echo -n 'var defaultConf = []byte(`' >> default.go
 cat ../default-config.toml >> default.go
 echo '`)' >> default.go

--- a/default-config.toml
+++ b/default-config.toml
@@ -118,6 +118,9 @@ other = 'off'
 #   cmd = ["feh"]
 #   types = ["image/jpeg"]
 #
+# Each command that you specify must come under its own [[mediatype-handlers]]. You may
+# specify as many [[mediatype-handlers]] as you want to setup multiple commands.
+#
 # If the subtype is omitted then the specified command will be used for the
 # entire type:
 #   [[mediatype-handlers]]
@@ -142,9 +145,6 @@ other = 'off'
 #   cmd = ["feh"]
 #   types = ["image"]
 #   no_prompt = true
-#
-# NOTE: There may be multiple [[mediatype-handlers]] specified to setup multiple
-# handler commands
 
 
 [cache]

--- a/default-config.toml
+++ b/default-config.toml
@@ -109,6 +109,13 @@ shift_numbers = "!@#$%^&*()"
 other = 'off'
 
 
+[mime-handlers]
+# Allows setting the commands to run for various mime types.
+# E.g. to open png files with the imagemagic display command:
+#   [mime-handlers."image/png"]
+#   command = "display"
+
+
 [cache]
 # Options for page cache - which is only for text/gemini pages
 # Increase the cache size to speed up browsing at the expense of memory

--- a/default-config.toml
+++ b/default-config.toml
@@ -113,7 +113,7 @@ other = 'off'
 # Allows setting the commands to run for various mime types.
 # E.g. to open png files with the imagemagic display command:
 #   [mime-handlers."image/png"]
-#   command = "display"
+#   command = ["display"]
 
 
 [cache]

--- a/default-config.toml
+++ b/default-config.toml
@@ -109,28 +109,38 @@ shift_numbers = "!@#$%^&*()"
 other = 'off'
 
 
-[mime-handlers]
-# Allows setting the commands to run for various mime types.
-# E.g. to open png files with the imagemagic display command:
-#   [mime-handlers."image/png"]
-#   command = ["display"]
+# [[mediatype-handlers]]
+# Allows setting the commands to run for various mediatypes.
 #
-# The subtype may be a * to open all files of a set type E.g:
-#   [mime-handlers."image/*"]
-#   command = ["display"]
+# To open jpeg files with the feh command:
+#   [[mediatype-handlers]]
+#   cmd = ["feh"]
+#   types = ["image/jpeg"]
 #
-# Both the type and subtype may be */* to specify the default handler.
+# If the subtype is ommited then the specified command will be used for the
+# entire type:
+#   [[mediatype-handlers]]
+#   command = ["vlc", "--flag"]
+#   types = ["audio", "video"]
 #
-# If command is "" or [] the file will be opened using the mozz.us http portal
-# and a-general.http
+# The default catch-all handler can by specified with an "*"
+#   [[mediatype-handlers]]
+#   cmd = ["some-command"]
+#   types = [
+#           "application/pdf",
+#           "*",
+#   ]
 #
-# Mime type handlers may also have an action field containing one of the following:
-# "prompt"   - Ask user every time which action to take.
-# "download" - Always download the file without prompting
-# "open"     - Always open the file using the below command without prompting
-[mime-handlers."*/*"]
-command = []
-action = "prompt"
+# If you want to always open a type in its viewer without the download or open
+# prompt appearing, you can add no_prompt = true
+#
+#   [[mediatype-handlers]]
+#   cmd = ["feh"]
+#   types = ["image"]
+#   no_prompt = true
+#
+# NOTE: There may be multiple [[mediatype-handlers]] specified to setup mutiple
+# handler commands
 
 
 [cache]

--- a/default-config.toml
+++ b/default-config.toml
@@ -123,8 +123,14 @@ other = 'off'
 #
 # If command is "" or [] the file will be opened using the mozz.us http portal
 # and a-general.http
+#
+# Mime type handlers may also have an action field containing one of the following:
+# "prompt"   - Ask user every time which action to take.
+# "download" - Always download the file without prompting
+# "open"     - Always open the file using the below command without prompting
 [mime-handlers."*/*"]
 command = []
+action = "prompt"
 
 
 [cache]

--- a/default-config.toml
+++ b/default-config.toml
@@ -110,20 +110,24 @@ other = 'off'
 
 
 # [[mediatype-handlers]]
-# Allows setting the commands to run for various mediatypes.
+# Specify what applications will open certain filetypes.
+# By default your default application will be used to open the file when you select "Open".
 #
 # To open jpeg files with the feh command:
 #   [[mediatype-handlers]]
 #   cmd = ["feh"]
 #   types = ["image/jpeg"]
 #
-# If the subtype is ommited then the specified command will be used for the
+# If the subtype is omitted then the specified command will be used for the
 # entire type:
 #   [[mediatype-handlers]]
 #   command = ["vlc", "--flag"]
 #   types = ["audio", "video"]
 #
-# The default catch-all handler can by specified with an "*"
+# A catch-all handler can by specified with "*".
+# Note that there are already catch-all handlers in place for all OSes,
+# that open the file using your default application. This is only if you
+# want to override that.
 #   [[mediatype-handlers]]
 #   cmd = ["some-command"]
 #   types = [
@@ -139,7 +143,7 @@ other = 'off'
 #   types = ["image"]
 #   no_prompt = true
 #
-# NOTE: There may be multiple [[mediatype-handlers]] specified to setup mutiple
+# NOTE: There may be multiple [[mediatype-handlers]] specified to setup multiple
 # handler commands
 
 

--- a/default-config.toml
+++ b/default-config.toml
@@ -110,8 +110,10 @@ other = 'off'
 
 
 # [[mediatype-handlers]]
-# Specify what applications will open certain filetypes.
+# Specify what applications will open certain media types.
 # By default your default application will be used to open the file when you select "Open".
+# You only need to configure this section if you want to override your default application,
+# or do special things like streaming.
 #
 # To open jpeg files with the feh command:
 #   [[mediatype-handlers]]
@@ -145,6 +147,14 @@ other = 'off'
 #   cmd = ["feh"]
 #   types = ["image"]
 #   no_prompt = true
+#
+# Note: Multiple handlers cannot be defined for the same full media type, but
+# still there needs to be an order for which handlers are used. The following
+# order applies regardless of the order written in the config:
+#
+# 1. Full media type: "image/jpeg"
+# 2. Just type: "image"
+# 3. Catch-all: "*"
 
 
 [cache]

--- a/default-config.toml
+++ b/default-config.toml
@@ -114,6 +114,17 @@ other = 'off'
 # E.g. to open png files with the imagemagic display command:
 #   [mime-handlers."image/png"]
 #   command = ["display"]
+#
+# The subtype may be a * to open all files of a set type E.g:
+#   [mime-handlers."image/*"]
+#   command = ["display"]
+#
+# Both the type and subtype may be */* to specify the default handler.
+#
+# If command is "" or [] the file will be opened using the mozz.us http portal
+# and a-general.http
+[mime-handlers."*/*"]
+command = []
 
 
 [cache]

--- a/display/download.go
+++ b/display/download.go
@@ -141,7 +141,7 @@ func dlChoice(text, u string, resp *gemini.Response) {
 	if choice == "Open" {
 		tabPages.HidePage("dlChoice")
 		App.Draw()
-		downloadAndOpen(u, resp)
+		open(u, resp)
 		return
 	}
 	tabPages.SwitchToPage(strconv.Itoa(curTab))
@@ -149,10 +149,10 @@ func dlChoice(text, u string, resp *gemini.Response) {
 	App.Draw()
 }
 
-// downloadAndOpen performs the same actions as downloadURL except it also opens the file.
+// open performs the same actions as downloadURL except it also opens the file.
 // If there is no system viewer configured for the particular mediatype, it opens it
 // with the default system viewer.
-func downloadAndOpen(u string, resp *gemini.Response) {
+func open(u string, resp *gemini.Response) {
 	mediaHandler := getMediaHandler(resp)
 	path := downloadURL(config.TempDownloadsDir, u, resp)
 	if path == "" {

--- a/display/download.go
+++ b/display/download.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gdamore/tcell"
 	"github.com/makeworld-the-better-one/amfora/config"
 	"github.com/makeworld-the-better-one/amfora/structs"
-	"github.com/makeworld-the-better-one/amfora/webbrowser"
+	"github.com/makeworld-the-better-one/amfora/sysopen"
 	"github.com/makeworld-the-better-one/go-gemini"
 	"github.com/makeworld-the-better-one/progressbar/v3"
 	"github.com/spf13/viper"
@@ -160,7 +160,7 @@ func downloadAndOpen(u string, resp *gemini.Response) {
 	}
 	if mediaHandler.Cmd == nil {
 		// Open with system default viewer
-		_, err := webbrowser.Open(path)
+		_, err := sysopen.Open(path)
 		if err != nil {
 			Error("System Viewer Error", err.Error())
 			return

--- a/display/download.go
+++ b/display/download.go
@@ -126,18 +126,17 @@ func openInSystem(u string, resp *gemini.Response) {
 	}
 	confKey := ("mime-handlers." + mediatype)
 	if viper.IsSet(confKey) {
-		mediaConf := viper.GetStringMapString(confKey)
-		cmd := mediaConf["command"]
-		if (cmd == "") {
+		mediaConf := viper.GetStringMap(confKey)
+		cmd := mediaConf["command"].([]string)
+		if (cmd == nil) {
 			openInProxy(u)
 			return
 		}
-		fields := strings.Fields(cmd)
 		path := downloadURL(config.TempDownloadsDir, u, resp)
 		if (path == "") {
 			return
 		}
-		err := exec.Command(fields[0], append(fields[1:], path)...).Start()
+		err := exec.Command(cmd[0], append(cmd[1:], path)...).Start()
 		if err != nil {
 			Error("System Viewer Error", "Error executing custom command: "+err.Error())
 			return

--- a/display/download.go
+++ b/display/download.go
@@ -124,7 +124,16 @@ func openInSystem(u string, resp *gemini.Response) {
 		openInProxy(u)
 		return
 	}
+	splitMime := strings.Split(mediatype, "/")
 	confKey := ("mime-handlers." + mediatype)
+	if !viper.IsSet(confKey) {
+		// Try with a wildcard subtype
+		confKey = ("mime-handlers." + splitMime[0] + "/*")
+	}
+	if !viper.IsSet(confKey) {
+		// Try with wildcard type and subtype
+		confKey = ("mime-handlers.*/*")
+	}
 	if viper.IsSet(confKey) {
 		mediaConf := viper.GetStringMap(confKey)
 		cmd := mediaConf["command"].([]string)

--- a/display/download.go
+++ b/display/download.go
@@ -176,7 +176,7 @@ func open(u string, resp *gemini.Response) {
 			Error("File Opening Error", "Error executing custom command: "+err.Error())
 			return
 		}
-		Info("Opened with "+cmd[0])
+		Info("Opened with " + cmd[0])
 	}
 	App.SetFocus(dlModal)
 	App.Draw()

--- a/display/download.go
+++ b/display/download.go
@@ -24,9 +24,9 @@ import (
 	"gitlab.com/tslocum/cview"
 )
 
-// For choosing between download and the portal - copy of YesNo basically
+// For choosing between download and opening - copy of YesNo basically
 var dlChoiceModal = cview.NewModal().
-	AddButtons([]string{"Download", "Open", "Cancel"})
+	AddButtons([]string{"Open", "Download", "Cancel"})
 
 // Channel to indicate what choice they made using the button text
 var dlChoiceCh = make(chan string)
@@ -101,8 +101,8 @@ func getMediaHandler(resp *gemini.Response) config.MediaHandler {
 		return ret
 	}
 
-	splitType := strings.Split(mediatype, "/")
-	if ret, ok := config.MediaHandlers[splitType[0]]; ok {
+	splitType := strings.Split(mediatype, "/")[0]
+	if ret, ok := config.MediaHandlers[splitType]; ok {
 		return ret
 	}
 
@@ -165,12 +165,12 @@ func downloadAndOpen(u string, resp *gemini.Response) {
 			Error("System Viewer Error", err.Error())
 			return
 		}
-		dlModal.SetText("Opened in system default viewer")
+		dlModal.SetText("Opened in default system viewer")
 	} else {
 		cmd := mediaHandler.Cmd
 		err := exec.Command(cmd[0], append(cmd[1:], path)...).Start()
 		if err != nil {
-			Error("System Viewer Error", "Error executing custom command: "+err.Error())
+			Error("File Opening Error", "Error executing custom command: "+err.Error())
 			return
 		}
 		dlModal.SetText("Opened in system viewer")
@@ -181,7 +181,7 @@ func downloadAndOpen(u string, resp *gemini.Response) {
 
 // downloadURL pulls up a modal to show download progress and saves the URL content.
 // downloadPage should be used for Page content.
-// Returns location downloaded to or an empty string on error
+// Returns location downloaded to or an empty string on error.
 func downloadURL(dir, u string, resp *gemini.Response) string {
 	_, _, width, _ := dlModal.GetInnerRect()
 	// Copy of progressbar.DefaultBytesSilent with custom width
@@ -273,7 +273,7 @@ func downloadPage(p *structs.Page) (string, error) {
 // downloadNameFromURL takes a URl and returns a safe download path that will not overwrite any existing file.
 // ext is an extension that will be added if the file has no extension, and for domain only URLs.
 // It should include the dot.
-func downloadNameFromURL(dir, u string, ext string) (string, error) {
+func downloadNameFromURL(dir, u, ext string) (string, error) {
 	var name string
 	var err error
 	parsed, _ := url.Parse(u)

--- a/display/download.go
+++ b/display/download.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -23,7 +25,7 @@ import (
 
 // For choosing between download and the portal - copy of YesNo basically
 var dlChoiceModal = cview.NewModal().
-	AddButtons([]string{"Download", "Open in portal", "Cancel"})
+	AddButtons([]string{"Download", "Open", "Cancel"})
 
 // Channel to indicate what choice they made using the button text
 var dlChoiceCh = make(chan string)
@@ -88,12 +90,6 @@ func dlInit() {
 func dlChoice(text, u string, resp *gemini.Response) {
 	defer resp.Body.Close()
 
-	parsed, err := url.Parse(u)
-	if err != nil {
-		Error("URL Error", err.Error())
-		return
-	}
-
 	dlChoiceModal.SetText(text)
 	tabPages.ShowPage("dlChoice")
 	tabPages.SendToFront("dlChoice")
@@ -104,25 +100,13 @@ func dlChoice(text, u string, resp *gemini.Response) {
 	if choice == "Download" {
 		tabPages.HidePage("dlChoice")
 		App.Draw()
-		downloadURL(u, resp)
+		downloadURL(config.DownloadsDir, u, resp)
 		return
 	}
-	if choice == "Open in portal" {
-		// Open in mozz's proxy
-		portalURL := u
-		if parsed.RawQuery != "" {
-			// Remove query and add encoded version on the end
-			query := parsed.RawQuery
-			parsed.RawQuery = ""
-			portalURL = parsed.String() + "%3F" + query
-		}
-		portalURL = strings.TrimPrefix(portalURL, "gemini://") + "?raw=1"
-		ok := handleHTTP("https://portal.mozz.us/gemini/"+portalURL, false)
-		if ok {
-			tabPages.SwitchToPage(strconv.Itoa(curTab))
-			App.SetFocus(tabs[curTab].view)
-			App.Draw()
-		}
+	if choice == "Open" {
+		tabPages.HidePage("dlChoice")
+		App.Draw()
+		openInSystem(u, resp)
 		return
 	}
 	tabPages.SwitchToPage(strconv.Itoa(curTab))
@@ -130,9 +114,69 @@ func dlChoice(text, u string, resp *gemini.Response) {
 	App.Draw()
 }
 
+// openInSystem performs the same actions as downloadURL except it also opens the file.
+// If there is no system viewer configured for the particular mime type, it opens it
+// with the normal http handler using portal.mozz.us.
+func openInSystem(u string, resp *gemini.Response) {
+	// TODO: currently we are ignoring the mediatype params.
+	mediatype, _, err := mime.ParseMediaType(resp.Meta)
+	if err != nil {
+		openInProxy(u)
+		return
+	}
+	confKey := ("mime-handlers." + mediatype)
+	if viper.IsSet(confKey) {
+		mediaConf := viper.GetStringMapString(confKey)
+		cmd := mediaConf["command"]
+		if (cmd == "") {
+			openInProxy(u)
+			return
+		}
+		fields := strings.Fields(cmd)
+		path := downloadURL(config.TempDownloadsDir, u, resp)
+		if (path == "") {
+			return
+		}
+		err := exec.Command(fields[0], append(fields[1:], path)...).Start()
+		if err != nil {
+			Error("System Viewer Error", "Error executing custom command: "+err.Error())
+			return
+		}
+		return
+	}
+	// Fallback to opening in proxy
+	openInProxy(u)
+}
+
+// openInProxy opens the url using the nomal http handler using portal.mozz.us
+func openInProxy(u string) {
+	// Open in mozz's proxy
+	parsed, err := url.Parse(u)
+	if err != nil {
+		Error("URL Error", err.Error())
+		return
+	}
+	portalURL := u
+
+	if parsed.RawQuery != "" {
+		// Remove query and add encoded version on the end
+		query := parsed.RawQuery
+		parsed.RawQuery = ""
+		portalURL = parsed.String() + "%3F" + query
+	}
+	portalURL = strings.TrimPrefix(portalURL, "gemini://") + "?raw=1"
+	ok := handleHTTP("https://portal.mozz.us/gemini/"+portalURL, false)
+	if ok {
+		tabPages.SwitchToPage(strconv.Itoa(curTab))
+		App.SetFocus(tabs[curTab].view)
+		App.Draw()
+	}
+}
+
 // downloadURL pulls up a modal to show download progress and saves the URL content.
 // downloadPage should be used for Page content.
-func downloadURL(u string, resp *gemini.Response) {
+// Returns location downloaded to or an empty string on error
+func downloadURL(dir, u string, resp *gemini.Response) string {
 	_, _, width, _ := dlModal.GetInnerRect()
 	// Copy of progressbar.DefaultBytesSilent with custom width
 	bar := progressbar.NewOptions64(
@@ -146,15 +190,15 @@ func downloadURL(u string, resp *gemini.Response) {
 	)
 	bar.RenderBlank() //nolint:errcheck
 
-	savePath, err := downloadNameFromURL(u, "")
+	savePath, err := downloadNameFromURL(dir, u, "")
 	if err != nil {
 		Error("Download Error", "Error deciding on file name: "+err.Error())
-		return
+		return ""
 	}
 	f, err := os.OpenFile(savePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		Error("Download Error", "Error creating download file: "+err.Error())
-		return
+		return ""
 	}
 	defer f.Close()
 
@@ -184,7 +228,7 @@ func downloadURL(u string, resp *gemini.Response) {
 		Error("Download Error", err.Error())
 		f.Close()
 		os.Remove(savePath) // Remove partial file
-		return
+		return ""
 	}
 	dlModal.SetText(fmt.Sprintf("Download complete! File saved to %s.", savePath))
 	dlModal.ClearButtons()
@@ -192,6 +236,8 @@ func downloadURL(u string, resp *gemini.Response) {
 	dlModal.GetForm().SetFocus(100)
 	App.SetFocus(dlModal)
 	App.Draw()
+
+	return savePath
 }
 
 // downloadPage saves the passed Page to a file.
@@ -202,9 +248,9 @@ func downloadPage(p *structs.Page) (string, error) {
 	var err error
 
 	if p.Mediatype == structs.TextGemini {
-		savePath, err = downloadNameFromURL(p.URL, ".gmi")
+		savePath, err = downloadNameFromURL(config.DownloadsDir, p.URL, ".gmi")
 	} else {
-		savePath, err = downloadNameFromURL(p.URL, ".txt")
+		savePath, err = downloadNameFromURL(config.DownloadsDir, p.URL, ".txt")
 	}
 	if err != nil {
 		return "", err
@@ -221,13 +267,13 @@ func downloadPage(p *structs.Page) (string, error) {
 // downloadNameFromURL takes a URl and returns a safe download path that will not overwrite any existing file.
 // ext is an extension that will be added if the file has no extension, and for domain only URLs.
 // It should include the dot.
-func downloadNameFromURL(u string, ext string) (string, error) {
+func downloadNameFromURL(dir, u string, ext string) (string, error) {
 	var name string
 	var err error
 	parsed, _ := url.Parse(u)
 	if parsed.Path == "" || path.Base(parsed.Path) == "/" {
 		// No file, just the root domain
-		name, err = getSafeDownloadName(parsed.Hostname()+ext, true, 0)
+		name, err = getSafeDownloadName(dir, parsed.Hostname()+ext, true, 0)
 		if err != nil {
 			return "", err
 		}
@@ -238,23 +284,23 @@ func downloadNameFromURL(u string, ext string) (string, error) {
 			// No extension
 			name += ext
 		}
-		name, err = getSafeDownloadName(name, false, 0)
+		name, err = getSafeDownloadName(dir, name, false, 0)
 		if err != nil {
 			return "", err
 		}
 	}
-	return filepath.Join(config.DownloadsDir, name), nil
+	return filepath.Join(dir, name), nil
 }
 
 // getSafeDownloadName is used by downloads.go only.
-// It returns a modified name that is unique for the downloads folder.
+// It returns a modified name that is unique for the specified folder.
 // This way duplicate saved files will not overwrite each other.
 //
 // lastDot should be set to true if the number added to the name should come before
 // the last dot in the filename instead of the first.
 //
 // n should be set to 0, it is used for recursiveness.
-func getSafeDownloadName(name string, lastDot bool, n int) (string, error) {
+func getSafeDownloadName(dir, name string, lastDot bool, n int) (string, error) {
 	// newName("test.txt", 3) -> "test(3).txt"
 	newName := func() string {
 		if n <= 0 {
@@ -271,7 +317,7 @@ func getSafeDownloadName(name string, lastDot bool, n int) (string, error) {
 		return name[:idx] + "(" + strconv.Itoa(n) + ")" + name[idx:]
 	}
 
-	d, err := os.Open(config.DownloadsDir)
+	d, err := os.Open(dir)
 	if err != nil {
 		return "", err
 	}
@@ -285,7 +331,7 @@ func getSafeDownloadName(name string, lastDot bool, n int) (string, error) {
 	for i := range files {
 		if nn == files[i] {
 			d.Close()
-			return getSafeDownloadName(name, lastDot, n+1)
+			return getSafeDownloadName(dir, name, lastDot, n+1)
 		}
 	}
 	d.Close()

--- a/display/download.go
+++ b/display/download.go
@@ -158,6 +158,9 @@ func open(u string, resp *gemini.Response) {
 	if path == "" {
 		return
 	}
+	tabPages.SwitchToPage(strconv.Itoa(curTab))
+	App.SetFocus(tabs[curTab].view)
+	App.Draw()
 	if mediaHandler.Cmd == nil {
 		// Open with system default viewer
 		_, err := sysopen.Open(path)
@@ -165,7 +168,7 @@ func open(u string, resp *gemini.Response) {
 			Error("System Viewer Error", err.Error())
 			return
 		}
-		dlModal.SetText("Opened in default system viewer")
+		Info("Opened in default system viewer")
 	} else {
 		cmd := mediaHandler.Cmd
 		err := exec.Command(cmd[0], append(cmd[1:], path)...).Start()
@@ -173,7 +176,7 @@ func open(u string, resp *gemini.Response) {
 			Error("File Opening Error", "Error executing custom command: "+err.Error())
 			return
 		}
-		dlModal.SetText("Opened with "+cmd[0])
+		Info("Opened with "+cmd[0])
 	}
 	App.SetFocus(dlModal)
 	App.Draw()

--- a/display/download.go
+++ b/display/download.go
@@ -88,7 +88,7 @@ func dlInit() {
 func getMediaConf(resp *gemini.Response) map[string]interface{} {
 	def := map[string]interface{}{
 		"command": nil,
-		"action": "prompt",
+		"action":  "prompt",
 	}
 
 	// TODO: currently we are ignoring the mediatype params.
@@ -157,15 +157,15 @@ func dlChoice(text, u string, resp *gemini.Response) {
 func openInSystem(u string, resp *gemini.Response) {
 	mediaConf := getMediaConf(resp)
 	var cmd []string
-	switch mediaConf["command"].(type) {
+	switch v := mediaConf["command"].(type) {
 	case []string:
-		cmd = mediaConf["command"].([]string)
+		cmd = v
 	default: // Including nil
 		openInProxy(u)
 		return
 	}
 	path := downloadURL(config.TempDownloadsDir, u, resp)
-	if (path == "") {
+	if path == "" {
 		return
 	}
 	err := exec.Command(cmd[0], append(cmd[1:], path)...).Start()

--- a/display/download.go
+++ b/display/download.go
@@ -173,7 +173,7 @@ func open(u string, resp *gemini.Response) {
 			Error("File Opening Error", "Error executing custom command: "+err.Error())
 			return
 		}
-		dlModal.SetText("Opened in system viewer")
+		dlModal.SetText("Opened with "+cmd[0])
 	}
 	App.SetFocus(dlModal)
 	App.Draw()

--- a/sysopen/README.md
+++ b/sysopen/README.md
@@ -1,0 +1,5 @@
+# `package sysopen`
+
+The code in this folder is adapted from Bombadillo, you can see the original [here](https://tildegit.org/sloum/bombadillo/src/branch/master/http). Many thanks to Sloum and the rest of the team!
+
+The code is simple, and I have changed it, but in any case there should be no licensing issues because both repos are under GPL v3.

--- a/sysopen/README.md
+++ b/sysopen/README.md
@@ -1,5 +1,0 @@
-# `package sysopen`
-
-The code in this folder is adapted from Bombadillo, you can see the original [here](https://tildegit.org/sloum/bombadillo/src/branch/master/http). Many thanks to Sloum and the rest of the team!
-
-The code is simple, and I have changed it, but in any case there should be no licensing issues because both repos are under GPL v3.

--- a/sysopen/open_browser_darwin.go
+++ b/sysopen/open_browser_darwin.go
@@ -1,0 +1,14 @@
+// +build darwin
+
+package sysopen
+
+import "os/exec"
+
+// Open opens `path` in default system viewer.
+func Open(path string) (string, error) {
+	err := exec.Command("open", path).Start()
+	if err != nil {
+		return "", err
+	}
+	return "Opened in default system viewer", nil
+}

--- a/sysopen/open_browser_other.go
+++ b/sysopen/open_browser_other.go
@@ -1,0 +1,10 @@
+// +build !linux,!darwin,!windows,!freebsd,!netbsd,!openbsd
+
+package sysopen
+
+import "fmt"
+
+// Open opens `path` in default system viewer, but not on this OS.
+func Open(path string) (string, error) {
+	return "", fmt.Errorf("unsupported OS for default system viewer. Set a default [[mediatype-handlers]] command in the config")
+}

--- a/sysopen/open_browser_other.go
+++ b/sysopen/open_browser_other.go
@@ -7,5 +7,5 @@ import "fmt"
 // Open opens `path` in default system viewer, but not on this OS.
 func Open(path string) (string, error) {
 	return "", fmt.Errorf("unsupported OS for default system viewer. " +
-		"Set a default [[mediatype-handlers]] command in the config")
+		"Set a catch-all [[mediatype-handlers]] command in the config")
 }

--- a/sysopen/open_browser_other.go
+++ b/sysopen/open_browser_other.go
@@ -6,5 +6,6 @@ import "fmt"
 
 // Open opens `path` in default system viewer, but not on this OS.
 func Open(path string) (string, error) {
-	return "", fmt.Errorf("unsupported OS for default system viewer. Set a default [[mediatype-handlers]] command in the config")
+	return "", fmt.Errorf("unsupported OS for default system viewer. " +
+		"Set a default [[mediatype-handlers]] command in the config")
 }

--- a/sysopen/open_browser_unix.go
+++ b/sysopen/open_browser_unix.go
@@ -21,7 +21,8 @@ func Open(path string) (string, error) {
 	)
 	switch {
 	case xorgDisplay == "" && waylandDisplay == "":
-		return "", fmt.Errorf("no display server was found. You may set a default [[mediatype-handlers]] command in the config")
+		return "", fmt.Errorf("no display server was found. " +
+			"You may set a default [[mediatype-handlers]] command in the config")
 	case xdgOpenNotFoundErr == nil:
 		// Use start rather than run or output in order
 		// to make application run in background.
@@ -30,6 +31,7 @@ func Open(path string) (string, error) {
 		}
 		return "Opened in default system viewer", nil
 	default:
-		return "", fmt.Errorf("could not determine default system viewer. Set a default [[mediatype-handlers]] command in the config")
+		return "", fmt.Errorf("could not determine default system viewer. " +
+			"Set a default [[mediatype-handlers]] command in the config")
 	}
 }

--- a/sysopen/open_browser_unix.go
+++ b/sysopen/open_browser_unix.go
@@ -1,0 +1,35 @@
+// +build linux freebsd netbsd openbsd
+
+//nolint:goerr113
+package sysopen
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// Open opens `path` in default system viewer. It tries to do so using
+// xdg-open. It only works if there is a display server working.
+func Open(path string) (string, error) {
+	var (
+		// In prev versions there was also Xorg executable checked for.
+		// I don't see any reason to check for it.
+		xorgDisplay                     = os.Getenv("DISPLAY")
+		waylandDisplay                  = os.Getenv("WAYLAND_DISPLAY")
+		xdgOpenPath, xdgOpenNotFoundErr = exec.LookPath("xdg-open")
+	)
+	switch {
+	case xorgDisplay == "" && waylandDisplay == "":
+		return "", fmt.Errorf("no display server was found. You may set a default [[mediatype-handlers]] command in the config")
+	case xdgOpenNotFoundErr == nil:
+		// Use start rather than run or output in order
+		// to make application run in background.
+		if err := exec.Command(xdgOpenPath, path).Start(); err != nil {
+			return "", err
+		}
+		return "Opened in default system viewer", nil
+	default:
+		return "", fmt.Errorf("could not determine default system viewer. Set a default [[mediatype-handlers]] command in the config")
+	}
+}

--- a/sysopen/open_browser_unix.go
+++ b/sysopen/open_browser_unix.go
@@ -13,8 +13,6 @@ import (
 // xdg-open. It only works if there is a display server working.
 func Open(path string) (string, error) {
 	var (
-		// In prev versions there was also Xorg executable checked for.
-		// I don't see any reason to check for it.
 		xorgDisplay                     = os.Getenv("DISPLAY")
 		waylandDisplay                  = os.Getenv("WAYLAND_DISPLAY")
 		xdgOpenPath, xdgOpenNotFoundErr = exec.LookPath("xdg-open")
@@ -32,6 +30,6 @@ func Open(path string) (string, error) {
 		return "Opened in default system viewer", nil
 	default:
 		return "", fmt.Errorf("could not determine default system viewer. " +
-			"Set a default [[mediatype-handlers]] command in the config")
+			"Set a catch-all [[mediatype-handlers]] command in the config")
 	}
 }

--- a/sysopen/open_browser_windows.go
+++ b/sysopen/open_browser_windows.go
@@ -1,0 +1,15 @@
+// +build windows
+// +build !linux !darwin !freebsd !netbsd !openbsd
+
+package sysopen
+
+import "os/exec"
+
+// Open opens `path` in default system vierwer.
+func Open(path string) (string, error) {
+	err := exec.Command("rundll32", "url.dll,FileProtocolHandler", path).Start()
+	if err != nil {
+		return "", err
+	}
+	return "Opened in default system viewer", nil
+}


### PR DESCRIPTION
This is a partial solution to #121. It uses a slightly different configuration syntax than the one proposed. It looks like this:

``` TOML
[mime-handlers]
# Allows setting the commands to run for various mime types.
# E.g. to open png files with the imagemagic display command:
#   [mime-handlers."image/png"]
#   command = ["display"]
#
# The subtype may be a * to open all files of a set type E.g:
#   [mime-handlers."image/*"]
#   command = ["display"]
#
# Both the type and subtype may be */* to specify the default handler.
#
# If command is "" or [] the file will be opened using the mozz.us http portal
# and a-general.http
#
# Mime type handlers may also have an action field containing one of the following:
# "prompt"   - Ask user every time which action to take.
# "download" - Always download the file without prompting
# "open"     - Always open the file using the below command without prompting
[mime-handlers."*/*"]
command = []
action = "prompt"

[mime-handlers."image/*"]
command = "display"
action = "open"
```

It leaves the mozz.us portal as the default, but it is trivial for a Linux user to add a `*/*` handler for `xdg-open`. On mac I think plain `open` works. I don't know about Windows though.

## Limitations

There are a handful of limitations with this implementation that I want to point out:

* Currently there is no piping/streaming. Files must be downloaded in full before opening
* Files are downloaded to the system temp dir (but this is configurable). They are never removed by amfora. I am relying on the system to clean the tmp folder on reboot.
* MIME parameters are ignored.
* Opening files in a TUI application (like vim/emacs/viu) is a bit tricky. A user would probably need to write a wrapper script