### PR TITLE
search: trim trailing whitespace

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -198,6 +198,11 @@ func Init(version, commit, builtBy string) {
 				} else {
 					// It's a full URL or search term
 					// Detect if it's a search or URL
+
+					// Remove whitespace from the string.
+					// We don't want to convert legitimate
+					// :// links to search terms.
+					query := strings.TrimSpace(query)
 					if (strings.Contains(query, " ") && !hasSpaceisURL.MatchString(query)) ||
 						(!strings.HasPrefix(query, "//") && !strings.Contains(query, "://") &&
 							!strings.Contains(query, ".")) && !strings.HasPrefix(query, "about:") {


### PR DESCRIPTION
When amforma is given a string to search, if that string contains a
valid protocol (gemini://), and that string contains trailing
whitespace, then the string is treated as a search term.

Although perhaps slightly more uncommon, if the input string was as a
result of copy/paste then it's possible the string could contain
trailing spaces, which is not what was intended, but rather should be
removed so that it's treated either as a valid gemini:// link or a
search term.

Some efforts around this appeared in #138

Note that with respect to #138, I wonder if there's still more work to be
done?  Currently, the following strings are considered valid search terms:

` abc`
`   gemini://xteddy.org`

At the moment, the check for this happens both in the form of a regexp, and
some other conditionals in `display/display.go`.  I think longer-term this
should be cleaned up, namely:

* Better define how search terms are recognised -- do we have a prefix for
  that, or do we just treat the absense of a protocol marker (`foo://`) as a
  legitimate seach term?  Either way, we should be ignoring any whitespace
  coming before something which contains a protocol, as in:

  `    gemini://xteddy.org`

  ... should not be treated as a search term.

* I am not sure regexing out the conditions for what is a valid protocol or a
  search term is necessarily the correct thing to do either.  Perhaps we could
  go down the quoting route, whereby if someone did this:

  `  "I want this"`

  ... as a search term, we treat the trailing space as noise and remove it,
  and then send along `I want this` as one term, without the quotes.  But
  there's no standard in knowing how `GUS` or `geminispace.info` will
  interpret that appropriately.
