### PR TITLE
treat command-line option the same as other links

### DIFF
--- a/amfora.go
+++ b/amfora.go
@@ -57,7 +57,7 @@ func main() {
 	display.NewTab() // Open extra tab and close it to fully initialize the app and wrapping
 	display.CloseTab()
 	if len(os.Args[1:]) > 0 {
-		display.URL(os.Args[1])
+		display.SearchOrLoad(os.Args[1], -1)
 	}
 
 	if err = display.App.Run(); err != nil {


### PR DESCRIPTION
When amfora is started as 'amfora foo' it assumes it's a valid URL and
tries to open that directly, resulting in a dial.tcp error, rather than
treating it as a search term.

The logic about how amfora hanles this should be the same within amfora
itself and when started via the CLI.

This PR currently moves the logic from the search bar to its own function and
calls it from that point, and amfora's `main` func.  This is very much a
band-aid approach, as there's logic in the existing implementation to also
look at tabs and position, etc., which should probably be moved elsewhere.

For now, it made more sense to me to standardise on the behaviour, and then
this can be cleaned up more fully over time.

I can understand why this PR might therefore be rejected.

Fixes #185
