### PR TITLE
Fix issue 198

### DIFF
--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -121,7 +121,7 @@ func parseBinding(cmd Command, binding string) {
 		binding = binding[4:]
 	}
 
-	if len(binding) == 1 {
+	if len([]rune(binding)) == 1 {
 		k = tcell.KeyRune
 		r = []rune(binding)[0]
 	} else if len(binding) == 0 {


### PR DESCRIPTION
`len(string)` returns bytes, not number of runes, so the "detect single character" clause breaks when passed a multibyte UTF-8 encoding.  Casting to `rune[]` causes it to count runes, and then we can correctly detect the "there is one character in the string" case.

Tested by setting up a multibyte key binding, and then using `tmux send-keys -t <pane-specifier>` to send key presses to amfora.  Looks like this fixes it entirely.