### PR TITLE
Added ability to save `about:` pages.

### DIFF
--- a/display/bookmarks.go
+++ b/display/bookmarks.go
@@ -152,7 +152,7 @@ func addBookmark() {
 	t := tabs[curTab]
 	p := t.page
 
-	if !t.hasContent() {
+	if !t.hasContent() || t.isAnAboutPage() {
 		// It's an about: page, or a malformed one
 		return
 	}

--- a/display/display.go
+++ b/display/display.go
@@ -155,7 +155,7 @@ func Init(version, commit, builtBy string) {
 				reset()
 				return
 			}
-			if query[0] == '.' && tabs[tab].hasContent() {
+			if query[0] == '.' && tabs[tab].hasContent() && !tabs[tab].isAnAboutPage() {
 				// Relative url
 				current, err := url.Parse(tabs[tab].page.URL)
 				if err != nil {
@@ -576,7 +576,7 @@ func Reload() {
 		return
 	}
 
-	if !tabs[curTab].hasContent() {
+	if !tabs[curTab].hasContent() || tabs[curTab].isAnAboutPage() {
 		return
 	}
 

--- a/display/display.go
+++ b/display/display.go
@@ -576,7 +576,7 @@ func Reload() {
 		return
 	}
 
-	if !tabs[curTab].hasContent() || tabs[curTab].isAnAboutPage() {
+	if !tabs[curTab].hasContent() {
 		return
 	}
 

--- a/display/download.go
+++ b/display/download.go
@@ -324,9 +324,7 @@ func downloadNameFromURL(dir, u, ext string) (string, error) {
 
 	parsed, _ := url.Parse(u)
 	if strings.HasPrefix(u, "about:") {
-		// Is an about page, trim out 'about:' for the filename to be saved.
-		pagePath := strings.TrimPrefix(u, "about:")
-		name, err = getSafeDownloadName(dir, pagePath+ext, true, 0)
+		name, err = getSafeDownloadName(dir, parsed.Opaque+ext, true, 0)
 		if err != nil {
 			return "", err
 		}

--- a/display/download.go
+++ b/display/download.go
@@ -323,9 +323,10 @@ func downloadNameFromURL(dir, u, ext string) (string, error) {
 	var err error
 
 	parsed, _ := url.Parse(u)
-	if strings.HasPrefix(parsed.String(), "about:") {
-		// Is an about page, use the entire page url since there is no hostname
-		name, err = getSafeDownloadName(dir, parsed.String()+ext, true, 0)
+	if strings.HasPrefix(u, "about:") {
+		// Is an about page, trim out 'about:' for the filename to be saved.
+		pagePath := strings.TrimPrefix(u, "about:")
+		name, err = getSafeDownloadName(dir, pagePath+ext, true, 0)
 		if err != nil {
 			return "", err
 		}

--- a/display/download.go
+++ b/display/download.go
@@ -321,8 +321,15 @@ func downloadPage(p *structs.Page) (string, error) {
 func downloadNameFromURL(dir, u, ext string) (string, error) {
 	var name string
 	var err error
+
 	parsed, _ := url.Parse(u)
-	if parsed.Path == "" || path.Base(parsed.Path) == "/" {
+	if strings.HasPrefix(parsed.String(), "about:") {
+		// Is an about page, use the entire page url since there is no hostname
+		name, err = getSafeDownloadName(dir, parsed.String()+ext, true, 0)
+		if err != nil {
+			return "", err
+		}
+	} else if parsed.Path == "" || path.Base(parsed.Path) == "/" {
 		// No file, just the root domain
 		name, err = getSafeDownloadName(dir, parsed.Hostname()+ext, true, 0)
 		if err != nil {
@@ -340,6 +347,7 @@ func downloadNameFromURL(dir, u, ext string) (string, error) {
 			return "", err
 		}
 	}
+
 	return filepath.Join(dir, name), nil
 }
 

--- a/display/handlers.go
+++ b/display/handlers.go
@@ -180,7 +180,7 @@ func handleURL(t *tab, u string, numRedirects int) (string, bool) {
 		t.mode = tabModeDone
 
 		go func(p *structs.Page) {
-			if b && t.hasContent() && viper.GetBool("subscriptions.popup") {
+			if b && t.hasContent() && !t.isAnAboutPage() && viper.GetBool("subscriptions.popup") {
 				// The current page might be an untracked feed, and the user wants
 				// to be notified in such cases.
 

--- a/display/private.go
+++ b/display/private.go
@@ -23,7 +23,7 @@ func followLink(t *tab, prev, next string) {
 		return
 	}
 
-	if t.hasContent() {
+	if t.hasContent() && !t.isAnAboutPage() {
 		nextURL, err := resolveRelLink(t, prev, next)
 		if err != nil {
 			Error("URL Error", err.Error())

--- a/display/subscriptions.go
+++ b/display/subscriptions.go
@@ -304,7 +304,7 @@ func addSubscription() {
 	t := tabs[curTab]
 	p := t.page
 
-	if !t.hasContent() {
+	if !t.hasContent() || t.isAnAboutPage() {
 		// It's an about: page, or a malformed one
 		return
 	}

--- a/display/tab.go
+++ b/display/tab.go
@@ -213,7 +213,7 @@ func (t *tab) pageDown() {
 }
 
 // hasContent returns false when the tab's page is malformed,
-// has no content or URL, or if it's an 'about:' page.
+// has no content or URL.
 func (t *tab) hasContent() bool {
 	if t.page == nil || t.view == nil {
 		return false
@@ -221,13 +221,15 @@ func (t *tab) hasContent() bool {
 	if t.page.URL == "" {
 		return false
 	}
-	if strings.HasPrefix(t.page.URL, "about:") {
-		return false
-	}
 	if t.page.Content == "" {
 		return false
 	}
 	return true
+}
+
+// isAnAboutPage returns true when the tab's page is an about page
+func (t *tab) isAnAboutPage() bool {
+	return strings.HasPrefix(t.page.URL, "about:")
 }
 
 // applyHorizontalScroll handles horizontal scroll logic including left margin resizing,

--- a/display/util.go
+++ b/display/util.go
@@ -90,7 +90,7 @@ func textWidth() int {
 // It also returns an error if it could not resolve the links, which should be displayed
 // to the user.
 func resolveRelLink(t *tab, prev, next string) (string, error) {
-	if !t.hasContent() {
+	if !t.hasContent() || t.isAnAboutPage() {
 		return next, nil
 	}
 


### PR DESCRIPTION
Hi, I've been using Amfora for short-while and wanted to contribute to this awesome project.  
**Proposed Changes:**  
- Extracted the about page check that is in `hasContent` to its own separate function as that was the only check prohibiting about page saves. Since a page's content has no implication on it being an about page, decoupling these checks seems like a good idea. But do let me know if this change does not make sense for the overall project, and I can look into other fixes.    
- Added a change to `downloadNameFromURL` so that when it's generating a filename for a saved about page, it uses the entire page url i.e. `about:subscriptions` as otherwise the filename was simply left blank.

Fixes #210 
  
P.S. I did not locate a contribution guide, so let me know if I went about something the wrong way. If there is such a guide, please do point me towards it.  