### PR TITLE
Add iceberg theme

### DIFF
--- a/contrib/themes/iceberg.toml
+++ b/contrib/themes/iceberg.toml
@@ -1,0 +1,112 @@
+[theme]
+# This section is for changing the COLORS used in Amfora.
+# These colors only apply if 'color' is enabled above.
+# Colors can be set using a W3C color name, or a hex value such as "#ffffff".
+
+# Note that not all colors will work on terminals that do not have truecolor support.
+# If you want to stick to the standard 16 or 256 colors, you can get
+# a list of those here: https://jonasjacek.github.io/colors/
+# DO NOT use the names from that site, just the hex codes.
+
+# Definitions:
+#   bg = background
+#   fg = foreground
+#   dl = download
+#   btn = button
+#   hdg = heading
+#   bkmk = bookmark
+#   modal = a popup window/box in the middle of the screen
+
+# EXAMPLES:
+# hdg_1 = "green"
+# hdg_2 = "#5f0000"
+
+# Available keys to set:
+
+# bg: background for pages, tab row, app in general
+# tab_num: The number/highlight of the tabs at the top
+# tab_divider: The color of the divider character between tab numbers: |
+# bottombar_label: The color of the prompt that appears when you press space
+# bottombar_text: The color of the text you type
+# bottombar_bg
+bg = "#161821"
+tab_num = "#6b7089"
+tab_divider = "#e2a478"
+bottombar_label = "#6b7089"
+bottombar_text = "#89b8c2"
+bottombar_bg = "#161821"
+
+# hdg_1
+# hdg_2
+# hdg_3
+# amfora_link: A link that Amfora supports viewing. For now this is only gemini://
+# foreign_link: HTTP(S), Gopher, etc
+# link_number: The silver number that appears to the left of a link
+# regular_text: Normal gemini text, and plaintext documents
+# quote_text
+# preformatted_text
+# list_text
+hdg_1 = "#c0ca8e"
+hdg_2 = "#e98989"
+hdg_3 = "#c6c8d1"
+amfora_link = "#6b7089"
+foreign_link = "#d2d4de"
+kink_number = "#95c4ce"
+regular_text = "#89b8c2"
+quote_text = "#e98989"
+preformatted_text = "#c6c8d1"
+list_text = "#84a0c6"
+
+# btn_bg: The bg color for all modal buttons
+# btn_text: The text color for all modal buttons
+btn_bg = "#e2a478"
+btn_text = "#89b8c2"
+
+# dl_choice_modal_bg
+# dl_choice_modal_text
+# dl_modal_bg
+# dl_modal_text
+# info_modal_bg
+# info_modal_text
+# error_modal_bg
+# error_modal_text
+# yesno_modal_bg
+# yesno_modal_text
+# tofu_modal_bg
+# tofu_modal_text
+# subscription_modal_bg
+# subscription_modal_text
+dl_choice_modal_bg = "#e27878"
+dl_choice_modal_text = "#89b8c2"
+dl_modal_bg = "#e27878"
+dl_modal_text = "#89b8c2"
+info_modal_bg = "#e27878"
+info_modal_text = "#89b8c2"
+error_modal_bg = "#e9b189"
+error_modal_text = "#89b8c2"
+yesno_modal_bg = "#e27878"
+yesno_modal_text = "#89b8c2"
+tofu_modal_bg = "#e27878"
+tofu_modal_text = "#89b8c2"
+subscription_modal_bg = "#e27878"
+subscription_modal_text = "#89b8c2"
+
+# input_modal_bg
+# input_modal_text
+# input_modal_field_bg: The bg of the input field, where you type the text
+# input_modal_field_text: The color of the text you type
+input_modal_bg = "#e27878"
+input_modal_text = "#89b8c2"
+input_modal_field_bg = "#e2a478"
+input_modal_field_text = "#89b8c2"
+
+# bkmk_modal_bg
+# bkmk_modal_text
+# bkmk_modal_label
+# bkmk_modal_field_bg
+# bkmk_modal_field_text
+bkmk_modal_bg = "#e27878"
+bkmk_modal_text = "#89b8c2"
+bkmk_modal_label = "#89b8c2"
+bkmk_modal_field_bg = "#e2a478"
+bkmk_modal_field_text = "#89b8c2"


### PR DESCRIPTION
Added the iceberg vim theme (dark version) found [here](https://cocopon.github.io/iceberg.vim/). I just thought it might be nice to add to the list. 
Here is a screenshot.
![14:05:21:20:29:57](https://user-images.githubusercontent.com/69134168/118343135-1bb89180-b4f5-11eb-9d25-3d0f23269a64.png)
