### PR TITLE
add omni by day & by night themes

### DIFF
--- a/contrib/themes/README.md
+++ b/contrib/themes/README.md
@@ -157,6 +157,18 @@ Contributed by **[@luetage](https://github.com/luetage)**
 
 ![screenshot of Tokyo Night theme](https://user-images.githubusercontent.com/13988217/130348393-69986b51-ddd7-4310-90ae-382461502535.png)
 
+## omni by day
+
+Contributed by **[@omnivagant](https://github.com/omnivagant)**
+
+![screenshot of omni-by-day v0.23](https://user-image.githubusercontent.com/omnivagant/cant-figure-out-how-to-do-this.png)
+
+## omni by night
+
+Contributed by **[@omnivagant](https://github.com/omnivagant)**
+
+![screenshot of omni-by-night v0.23](https://user-image.githubusercontent.com/omnivagant/cant-figure-out-how-to-do-this.png)
+
 ## Yours?
 
 Contribute your own theme by opening a PR.

--- a/contrib/themes/omni-by-day.toml
+++ b/contrib/themes/omni-by-day.toml
@@ -1,0 +1,23 @@
+[theme]
+
+# omni by day v0.23
+
+#bg =                        "#f8eec8" # override "default"
+fg =                        "#5c5c5c"
+tab_num =                   "#dddddd"
+tab_divider =               "#424242"
+bottombar_label =           "#5c5c5c"
+bottombar_text =            "#777777"
+bottombar_bg =              "#dddddd"
+scrollbar =                 "#dddddd"
+
+hdg_1 =                     "#af3a03"
+hdg_2 =                     "#d65f0e"
+hdg_3 =                     "#d79921"
+amfora_link =               "#42cc00"
+foreign_link =              "#0f51ec"
+link_number =               "#a8a19f"
+regular_text =              "#5c5c5c"
+quote_text =                "#777777"
+preformatted_text =         "#777777"
+list_text =                 "#a8a19f"

--- a/contrib/themes/omni-by-night.toml
+++ b/contrib/themes/omni-by-night.toml
@@ -1,0 +1,23 @@
+[theme]
+
+# omni by night v0.23
+
+#bg =                        "#322825" # override "default"
+fg =                        "#a8a19f"
+tab_num =                   "#5c5c5c"
+tab_divider =               "#9c9c9c"
+bottombar_label =           "#7cfc00"
+bottombar_text =            "#ff9000"
+bottombar_bg =              "#333333"
+scrollbar =                 "#dddddd"
+
+hdg_1 =                     "#ff6000"
+hdg_2 =                     "#ff9000"
+hdg_3 =                     "#ffb000"
+amfora_link =               "#7cfc00"
+foreign_link =              "#f723ee"
+link_number =               "#dfbf8e"
+regular_text =              "#ebdbb2"
+quote_text =                "#ebdbb2"
+preformatted_text =         "#ebdbb2"
+list_text =                 "#ebdbb2"


### PR DESCRIPTION
I think the commented out values are the default ones, but it was some months since I did this. I could probably clean this up a bit, but I wanted to share.

Myself, I now use transparent terminals and background = "default".