### PR TITLE
Add RPM spec file

### DIFF
--- a/amfora.spec
+++ b/amfora.spec
@@ -1,0 +1,44 @@
+Summary: a Gemini browser for your terminal
+Name: amfora
+Version: 1.8.0
+Release: 1%{?dist}
+License: GPL
+URL: https://github.com/makeworld-the-better-one/amfora
+Source: https://github.com/makeworld-the-better-one/amfora/archive/v%{version}.tar.gz
+
+BuildRequires: make
+BuildRequires: git
+BuildRequires: gcc
+BuildRequires: golang
+
+Requires: ncurses-base
+
+%global debug_package %{nil}
+
+%description
+Amfora aims to be the best looking Gemini client with the most features... all in the terminal.
+
+%prep
+%setup -q
+
+%build
+%make_build %{?_smp_mflags} PREFIX=%{_prefix}
+
+%install
+mkdir -p %{buildroot}%{_prefix}
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_datadir}/applications/
+%make_install PREFIX=%{buildroot}%{_prefix}
+
+%files
+%{_bindir}/amfora
+%{_datadir}/applications/amfora.desktop
+%doc README.md
+%license LICENSE
+
+%changelog
+* Sun Oct 3 2021 Adam Thiede <adamj@mailbox.org>
+- Updated version and cleaned spec file for upload
+
+* Sun Nov 29 2020 Adam Thiede <adamj@mailbox.org>
+- Created spec file

--- a/amfora.spec
+++ b/amfora.spec
@@ -32,7 +32,7 @@ Amfora aims to be the best looking Gemini client with the most features... all i
 %setup -q
 
 %build
-%make_build %{?_smp_mflags} PREFIX=%{_prefix}
+%make_build BUILDER="official-rpm" %{?_smp_mflags} PREFIX=%{_prefix}
 
 %install
 mkdir -p %{buildroot}%{_prefix}

--- a/amfora.spec
+++ b/amfora.spec
@@ -9,7 +9,17 @@ Source: https://github.com/makeworld-the-better-one/amfora/archive/v%{version}.t
 BuildRequires: make
 BuildRequires: git
 BuildRequires: gcc
+# suse package: go
+# fedora/rhel package: golang
+%if 0%{?suse_version}
+BuildRequires: go
+%endif
+%if 0%{?fedora}
 BuildRequires: golang
+%endif
+%if 0%{?rhel}
+BuildRequires: golang
+%endif
 
 Requires: ncurses-base
 


### PR DESCRIPTION
I made a basic spec file for packaging in RPM-based distributions. When new versions of amfora are created the spec file should be updated at the top (`Version: 1.8.0` currently) and the bottom (new entry under `%changelog`).
It builds in current Fedora versions, RHEL8, and openSUSE Tumbleweed. https://copr.fedorainfracloud.org/coprs/adamthiede/bin/build/2872181/