### PR TITLE
Switch on debug logs via env var flag

### DIFF
--- a/amfora.go
+++ b/amfora.go
@@ -21,14 +21,14 @@ var (
 )
 
 func main() {
-	debugModeEnabled := os.Getenv("DEBUG")
-	if debugModeEnabled != "" {
-		err := logger.Init()
-		if err != nil {
-			panic(err)
-		}
+	log, err := logger.GetLogger()
+	if err != nil {
+		panic(err)
+	}
 
-		logger.Log.Println("Debug mode enabled")
+	debugModeEnabled := os.Getenv("DEBUG") == "1"
+	if debugModeEnabled {
+		log.Println("Debug mode enabled")
 	}
 
 	if len(os.Args) > 1 {
@@ -48,7 +48,7 @@ func main() {
 		}
 	}
 
-	err := config.Init()
+	err = config.Init()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Config error: %v\n", err)
 		os.Exit(1)

--- a/amfora.go
+++ b/amfora.go
@@ -26,7 +26,7 @@ func main() {
 		panic(err)
 	}
 
-	debugModeEnabled := os.Getenv("DEBUG") == "1"
+	debugModeEnabled := os.Getenv("AMFORA_DEBUG") == "1"
 	if debugModeEnabled {
 		log.Println("Debug mode enabled")
 	}

--- a/amfora.go
+++ b/amfora.go
@@ -11,6 +11,7 @@ import (
 	"github.com/makeworld-the-better-one/amfora/config"
 	"github.com/makeworld-the-better-one/amfora/display"
 	"github.com/makeworld-the-better-one/amfora/subscriptions"
+	"github.com/makeworld-the-better-one/amfora/logger"
 )
 
 var (
@@ -20,10 +21,15 @@ var (
 )
 
 func main() {
-	// err := logger.Init()
-	// if err != nil {
-	// 	panic(err)
-	// }
+    debugModeEnabled := os.Getenv("DEBUG")
+    if debugModeEnabled != "" {
+        err := logger.Init()
+        if err != nil {
+        	panic(err)
+        }
+
+        logger.Log.Println("Debug mode enabled")
+    }
 
 	if len(os.Args) > 1 {
 		if os.Args[1] == "--version" || os.Args[1] == "-v" {

--- a/amfora.go
+++ b/amfora.go
@@ -10,8 +10,8 @@ import (
 	"github.com/makeworld-the-better-one/amfora/client"
 	"github.com/makeworld-the-better-one/amfora/config"
 	"github.com/makeworld-the-better-one/amfora/display"
-	"github.com/makeworld-the-better-one/amfora/subscriptions"
 	"github.com/makeworld-the-better-one/amfora/logger"
+	"github.com/makeworld-the-better-one/amfora/subscriptions"
 )
 
 var (
@@ -21,15 +21,15 @@ var (
 )
 
 func main() {
-    debugModeEnabled := os.Getenv("DEBUG")
-    if debugModeEnabled != "" {
-        err := logger.Init()
-        if err != nil {
-        	panic(err)
-        }
+	debugModeEnabled := os.Getenv("DEBUG")
+	if debugModeEnabled != "" {
+		err := logger.Init()
+		if err != nil {
+			panic(err)
+		}
 
-        logger.Log.Println("Debug mode enabled")
-    }
+		logger.Log.Println("Debug mode enabled")
+	}
 
 	if len(os.Args) > 1 {
 		if os.Args[1] == "--version" || os.Args[1] == "-v" {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,18 +3,42 @@ package logger
 // For debugging
 
 import (
+	"io"
+	"io/ioutil"
 	"log"
 	"os"
 )
 
-var Log *log.Logger
+var logger *log.Logger
 
-func Init() error {
-	f, err := os.Create("debug.log")
-	if err != nil {
-		return err
+func GetLogger() (*log.Logger, error) {
+	if logger != nil {
+		return logger, nil
 	}
-	Log = log.New(f, "", log.LstdFlags)
-	Log.Println("Started Log")
-	return nil
+
+	var writer io.Writer
+	var err error
+
+	debugModeEnabled := os.Getenv("DEBUG") == "1"
+	if debugModeEnabled {
+		writer, err = os.Create("debug.log")
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Suppress all logging output if debug mode is disabled
+		writer = ioutil.Discard
+	}
+
+	logger = log.New(writer, "", log.LstdFlags)
+
+	if !debugModeEnabled {
+		// Clear all flags to skip log output formatting step to increase
+		// performance somewhat if we're not logging anything
+		logger.SetFlags(0)
+	}
+
+	logger.Println("Started logger")
+
+	return logger, nil
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -19,7 +19,7 @@ func GetLogger() (*log.Logger, error) {
 	var writer io.Writer
 	var err error
 
-	debugModeEnabled := os.Getenv("DEBUG") == "1"
+	debugModeEnabled := os.Getenv("AMFORA_DEBUG") == "1"
 	if debugModeEnabled {
 		writer, err = os.Create("debug.log")
 		if err != nil {


### PR DESCRIPTION
Use an environment variable as a flag to easily switch on the amfora
debug logger without requiring a code change.

Sample usage

```
$ DEBUG=1 amfora
```

The rest of the logging behaviour has been preserved although I'm thinking of further improvements that could be made to it, such as structured logs for easier filtering and parsing by tools (e.g. JSON and jq), increase log coverage, etc.