### PR TITLE
Fix users being unable to exit help menu

### DIFF
--- a/display/bookmarks.go
+++ b/display/bookmarks.go
@@ -29,7 +29,7 @@ var bkmkCh = make(chan bkmkAction)
 var bkmkModalText string // The current text of the input field in the modal
 
 func bkmkInit() {
-	panels.AddPanel("bkmk", bkmkModal, false, false)
+	panels.AddPanel(PanelBookmarks, bkmkModal, false, false)
 
 	m := bkmkModal
 	if viper.GetBool("a-general.color") {
@@ -111,13 +111,13 @@ func openBkmkModal(name string, exists bool) (string, bkmkAction) {
 			bkmkModalText = text
 		})
 
-	panels.ShowPanel("bkmk")
-	panels.SendToFront("bkmk")
+	panels.ShowPanel(PanelBookmarks)
+	panels.SendToFront(PanelBookmarks)
 	App.SetFocus(bkmkModal)
 	App.Draw()
 
 	action := <-bkmkCh
-	panels.HidePanel("bkmk")
+	panels.HidePanel(PanelBookmarks)
 	App.SetFocus(tabs[curTab].view)
 	App.Draw()
 

--- a/display/display.go
+++ b/display/display.go
@@ -87,7 +87,7 @@ func Init(version, commit, builtBy string) {
 		}(tabs[curTab])
 	})
 
-	panels.AddPanel("browser", browser, true, true)
+	panels.AddPanel(PanelBrowser, browser, true, true)
 
     helpInit()
 
@@ -280,7 +280,7 @@ func Init(version, commit, builtBy string) {
 			return event
 		}
         frontPanelName, _ := panels.GetFrontPanel()
-        if frontPanelName == "help" {
+        if frontPanelName == PanelHelp {
 			// It's focused on help right now
             return event
         }

--- a/display/display.go
+++ b/display/display.go
@@ -89,7 +89,7 @@ func Init(version, commit, builtBy string) {
 
 	panels.AddPanel(PanelBrowser, browser, true, true)
 
-    helpInit()
+	helpInit()
 
 	layout.SetDirection(cview.FlexRow)
 	layout.AddItem(panels, 0, 1, true)
@@ -279,11 +279,11 @@ func Init(version, commit, builtBy string) {
 			// It's focused on a modal right now, nothing should interrupt
 			return event
 		}
-        frontPanelName, _ := panels.GetFrontPanel()
-        if frontPanelName == PanelHelp {
+		frontPanelName, _ := panels.GetFrontPanel()
+		if frontPanelName == PanelHelp {
 			// It's focused on help right now
-            return event
-        }
+			return event
+		}
 
 		// To add a configurable global key command, you'll need to update one of
 		// the two switch statements here.  You'll also need to add an enum entry in

--- a/display/display.go
+++ b/display/display.go
@@ -89,7 +89,7 @@ func Init(version, commit, builtBy string) {
 
 	panels.AddPanel("browser", browser, true, true)
 
-	helpInit()
+    helpInit()
 
 	layout.SetDirection(cview.FlexRow)
 	layout.AddItem(panels, 0, 1, true)
@@ -279,11 +279,11 @@ func Init(version, commit, builtBy string) {
 			// It's focused on a modal right now, nothing should interrupt
 			return event
 		}
-		_, ok = App.GetFocus().(*cview.Table)
-		if ok {
+        frontPanelName, _ := panels.GetFrontPanel()
+        if frontPanelName == "help" {
 			// It's focused on help right now
-			return event
-		}
+            return event
+        }
 
 		// To add a configurable global key command, you'll need to update one of
 		// the two switch statements here.  You'll also need to add an enum entry in

--- a/display/display.go
+++ b/display/display.go
@@ -282,6 +282,13 @@ func Init(version, commit, builtBy string) {
 		frontPanelName, _ := panels.GetFrontPanel()
 		if frontPanelName == PanelHelp {
 			// It's focused on help right now
+			if config.TranslateKeyEvent(event) == config.CmdQuit {
+				// Allow quit key to work, but nothing else
+				Stop()
+				return nil
+			}
+			// Pass everything else directly, inhibiting other keybindings
+			// like for editing the URL
 			return event
 		}
 

--- a/display/download.go
+++ b/display/download.go
@@ -33,8 +33,8 @@ var dlChoiceCh = make(chan string)
 var dlModal = cview.NewModal()
 
 func dlInit() {
-	panels.AddPanel("dl", dlModal, false, false)
-	panels.AddPanel("dlChoice", dlChoiceModal, false, false)
+	panels.AddPanel(PanelDownload, dlModal, false, false)
+	panels.AddPanel(PanelDownloadChoiceModal, dlChoiceModal, false, false)
 
 	dlm := dlModal
 	chm := dlChoiceModal
@@ -96,7 +96,7 @@ func dlInit() {
 	frame.SetTitle(" Download ")
 	dlm.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 		if buttonLabel == "Ok" {
-			panels.HidePanel("dl")
+			panels.HidePanel(PanelDownload)
 			App.SetFocus(tabs[curTab].view)
 			App.Draw()
 		}
@@ -141,29 +141,29 @@ func dlChoice(text, u string, resp *gemini.Response) {
 		choice = "Open"
 	} else {
 		dlChoiceModal.SetText(text)
-		panels.ShowPanel("dlChoice")
-		panels.SendToFront("dlChoice")
+		panels.ShowPanel(PanelDownloadChoiceModal)
+		panels.SendToFront(PanelDownloadChoiceModal)
 		App.SetFocus(dlChoiceModal)
 		App.Draw()
 		choice = <-dlChoiceCh
 	}
 
 	if choice == "Download" {
-		panels.HidePanel("dlChoice")
+		panels.HidePanel(PanelDownloadChoiceModal)
 		App.Draw()
 		downloadURL(config.DownloadsDir, u, resp)
 		resp.Body.Close() // Only close when the file is downloaded
 		return
 	}
 	if choice == "Open" {
-		panels.HidePanel("dlChoice")
+		panels.HidePanel(PanelDownloadChoiceModal)
 		App.Draw()
 		open(u, resp)
 		return
 	}
 
 	// They chose the "Cancel" button
-	panels.HidePanel("dlChoice")
+	panels.HidePanel(PanelDownloadChoiceModal)
 	App.SetFocus(tabs[curTab].view)
 	App.Draw()
 }
@@ -200,7 +200,7 @@ func open(u string, resp *gemini.Response) {
 		return
 	}
 
-	panels.HidePanel("dl")
+	panels.HidePanel(PanelDownload)
 	App.SetFocus(tabs[curTab].view)
 	App.Draw()
 
@@ -267,15 +267,15 @@ func downloadURL(dir, u string, resp *gemini.Response) string {
 	// Display
 	dlModal.ClearButtons()
 	dlModal.AddButtons([]string{"Downloading..."})
-	panels.ShowPanel("dl")
-	panels.SendToFront("dl")
+	panels.ShowPanel(PanelDownload)
+	panels.SendToFront(PanelDownload)
 	App.SetFocus(dlModal)
 	App.Draw()
 
 	_, err = io.Copy(io.MultiWriter(f, bar), resp.Body)
 	done = true
 	if err != nil {
-		panels.HidePanel("dl")
+		panels.HidePanel(PanelDownload)
 		Error("Download Error", err.Error())
 		f.Close()
 		os.Remove(savePath) // Remove partial file

--- a/display/help.go
+++ b/display/help.go
@@ -55,8 +55,8 @@ var helpTable = cview.NewTextView()
 // Help displays the help and keybindings.
 func Help() {
 	helpTable.ScrollToBeginning()
-	panels.ShowPanel("help")
-	panels.SendToFront("help")
+	panels.ShowPanel(PanelHelp)
+	panels.SendToFront(PanelHelp)
 	App.SetFocus(helpTable)
 }
 
@@ -67,7 +67,7 @@ func helpInit() {
 	helpTable.SetPadding(0, 0, 1, 1)
 	helpTable.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEsc || key == tcell.KeyEnter {
-			panels.HidePanel("help")
+			panels.HidePanel(PanelHelp)
 			App.SetFocus(tabs[curTab].view)
 			App.Draw()
 		}
@@ -122,5 +122,5 @@ func helpInit() {
 
 	w.Flush()
 
-	panels.AddPanel("help", helpTable, true, false)
+	panels.AddPanel(PanelHelp, helpTable, true, false)
 }

--- a/display/modals.go
+++ b/display/modals.go
@@ -35,10 +35,10 @@ func modalInit() {
 
 	yesNoModal.AddButtons([]string{"Yes", "No"})
 
-	panels.AddPanel("info", infoModal, false, false)
-	panels.AddPanel("error", errorModal, false, false)
-	panels.AddPanel("input", inputModal, false, false)
-	panels.AddPanel("yesno", yesNoModal, false, false)
+	panels.AddPanel(PanelInfoModal, infoModal, false, false)
+	panels.AddPanel(PanelErrorModal, errorModal, false, false)
+	panels.AddPanel(PanelInputModal, inputModal, false, false)
+	panels.AddPanel(PanelYesNoModal, yesNoModal, false, false)
 
 	// Color setup
 	if viper.GetBool("a-general.color") {
@@ -141,7 +141,7 @@ func modalInit() {
 	frame.SetTitleAlign(cview.AlignCenter)
 	frame.SetTitle(" Info ")
 	infoModal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-		panels.HidePanel("info")
+		panels.HidePanel(PanelInfoModal)
 		App.SetFocus(tabs[curTab].view)
 		App.Draw()
 	})
@@ -149,7 +149,7 @@ func modalInit() {
 	errorModal.SetBorder(true)
 	errorModal.GetFrame().SetTitleAlign(cview.AlignCenter)
 	errorModal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-		panels.HidePanel("error")
+		panels.HidePanel(PanelErrorModal)
 		App.SetFocus(tabs[curTab].view)
 		App.Draw()
 	})
@@ -196,8 +196,8 @@ func Error(title, text string) {
 
 	errorModal.GetFrame().SetTitle(title)
 	errorModal.SetText(text)
-	panels.ShowPanel("error")
-	panels.SendToFront("error")
+	panels.ShowPanel(PanelErrorModal)
+	panels.SendToFront(PanelErrorModal)
 	App.SetFocus(errorModal)
 	App.Draw()
 }
@@ -205,8 +205,8 @@ func Error(title, text string) {
 // Info displays some info on the screen in a modal.
 func Info(s string) {
 	infoModal.SetText(s)
-	panels.ShowPanel("info")
-	panels.SendToFront("info")
+	panels.ShowPanel(PanelInfoModal)
+	panels.SendToFront(PanelInfoModal)
 	App.SetFocus(infoModal)
 	App.Draw()
 }
@@ -236,14 +236,14 @@ func Input(prompt string, sensitive bool) (string, bool) {
 	}
 
 	inputModal.SetText(prompt + " ")
-	panels.ShowPanel("input")
-	panels.SendToFront("input")
+	panels.ShowPanel(PanelInputModal)
+	panels.SendToFront(PanelInputModal)
 	App.SetFocus(inputModal)
 	App.Draw()
 
 	resp := <-inputCh
 
-	panels.HidePanel("input")
+	panels.HidePanel(PanelInputModal)
 	App.SetFocus(tabs[curTab].view)
 	App.Draw()
 
@@ -272,13 +272,13 @@ func YesNo(prompt string) bool {
 	}
 	yesNoModal.GetFrame().SetTitle("")
 	yesNoModal.SetText(prompt)
-	panels.ShowPanel("yesno")
-	panels.SendToFront("yesno")
+	panels.ShowPanel(PanelYesNoModal)
+	panels.SendToFront(PanelYesNoModal)
 	App.SetFocus(yesNoModal)
 	App.Draw()
 
 	resp := <-yesNoCh
-	panels.HidePanel("yesno")
+	panels.HidePanel(PanelYesNoModal)
 	App.SetFocus(tabs[curTab].view)
 	App.Draw()
 	return resp
@@ -310,13 +310,13 @@ func Tofu(host string, expiry time.Time) bool {
 			humanize.Time(expiry),
 		),
 	)
-	panels.ShowPanel("yesno")
-	panels.SendToFront("yesno")
+	panels.ShowPanel(PanelYesNoModal)
+	panels.SendToFront(PanelYesNoModal)
 	App.SetFocus(yesNoModal)
 	App.Draw()
 
 	resp := <-yesNoCh
-	panels.HidePanel("yesno")
+	panels.HidePanel(PanelYesNoModal)
 	App.SetFocus(tabs[curTab].view)
 	App.Draw()
 	return resp

--- a/display/panels.go
+++ b/display/panels.go
@@ -1,0 +1,14 @@
+package display
+
+const (
+    PanelBrowser = "browser"
+    PanelBookmarks = "bkmk"
+    PanelDownload = "dl"
+    PanelDownloadChoiceModal = "dlChoice"
+    PanelHelp = "help"
+
+    PanelYesNoModal = "yesno"
+    PanelInfoModal = "info"
+    PanelErrorModal = "error"
+    PanelInputModal = "input"
+)

--- a/display/panels.go
+++ b/display/panels.go
@@ -1,14 +1,14 @@
 package display
 
 const (
-    PanelBrowser = "browser"
-    PanelBookmarks = "bkmk"
-    PanelDownload = "dl"
-    PanelDownloadChoiceModal = "dlChoice"
-    PanelHelp = "help"
+	PanelBrowser             = "browser"
+	PanelBookmarks           = "bkmk"
+	PanelDownload            = "dl"
+	PanelDownloadChoiceModal = "dlChoice"
+	PanelHelp                = "help"
 
-    PanelYesNoModal = "yesno"
-    PanelInfoModal = "info"
-    PanelErrorModal = "error"
-    PanelInputModal = "input"
+	PanelYesNoModal = "yesno"
+	PanelInfoModal  = "info"
+	PanelErrorModal = "error"
+	PanelInputModal = "input"
 )

--- a/display/subscriptions.go
+++ b/display/subscriptions.go
@@ -260,13 +260,13 @@ func openSubscriptionModal(validFeed, subscribed bool) bool {
 		}
 	}
 
-	panels.ShowPanel("yesno")
-	panels.SendToFront("yesno")
+	panels.ShowPanel(PanelYesNoModal)
+	panels.SendToFront(PanelYesNoModal)
 	App.SetFocus(yesNoModal)
 	App.Draw()
 
 	resp := <-yesNoCh
-	panels.HidePanel("yesno")
+	panels.HidePanel(PanelYesNoModal)
 	App.SetFocus(tabs[curTab].view)
 	App.Draw()
 	return resp


### PR DESCRIPTION
Ignore any keypresses that don't have a corresponding binding in the Help page to avoid users triggering keybindings that remove the focus from the Help screen and becoming unable to exit, as Help keybindings are no longer captured correctly.

Rather than adding unnecessary complexity to make the Help page more flexible and capable of handling input events meant for other panels, I opted to restrict the input set to the keybindings that have a corresponding action in the Help page while it's active.

Closes #241 .