### PR TITLE
Auto redirect if the new URL just adds a trailing slash

### DIFF
--- a/display/handlers.go
+++ b/display/handlers.go
@@ -380,9 +380,10 @@ func handleURL(t *tab, u string, numRedirects int) (string, bool) {
 			return ret("", false)
 		}
 		redir := parsed.ResolveReference(parsedMeta).String()
+		justAddsSlash := (redir == u + "/")
 		// Prompt before redirecting to non-Gemini protocol
 		redirect := false
-		if !strings.HasPrefix(redir, "gemini") {
+		if !justAddsSlash && !strings.HasPrefix(redir, "gemini") {
 			if YesNo("Follow redirect to non-Gemini URL?\n" + redir) {
 				redirect = true
 			} else {
@@ -390,7 +391,7 @@ func handleURL(t *tab, u string, numRedirects int) (string, bool) {
 			}
 		}
 		// Prompt before redirecting
-		autoRedirect := viper.GetBool("a-general.auto_redirect")
+		autoRedirect := justAddsSlash || viper.GetBool("a-general.auto_redirect")
 		if redirect || (autoRedirect && numRedirects < 5) || YesNo("Follow redirect?\n"+redir) {
 			if res.Status == gemini.StatusRedirectPermanent {
 				go cache.AddRedir(u, redir)


### PR DESCRIPTION
These redirects are probably necessary, not going anywhere & harmless, let's not prompt for them

e.g. gemini://some-place/~user => gemini://some-place/~user/