### PR TITLE
🐛 Fix deadlock when an about: URL can't be loaded

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -540,13 +540,10 @@ func Reload() {
 func URL(u string) {
 	t := tabs[curTab]
 	if strings.HasPrefix(u, "about:") {
-		if final, ok := handleAbout(t, u); ok {
-			t.addToHistory(final)
-		}
-		return
+		go goURL(t, u)
+	} else {
+		go goURL(t, fixUserURL(u))
 	}
-
-	go goURL(t, fixUserURL(u))
 }
 
 func RenderFromString(str string) {


### PR DESCRIPTION
Caused by display.Error() being made to block for the loading page change.

We must call goURL / handleURL from a goroutine other than the main UI loop

I don't think there are any other problematic calls at the moment

Sorry :)