### PR TITLE
Fixed error when including theme.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -348,6 +348,9 @@ func Init() error {
 	cache.SetTimeout(viper.GetInt("cache.timeout"))
 
 	setColor := func(k string, colorStr string) error {
+		if k == "include" {
+			return nil
+		}
 		colorStr = strings.ToLower(colorStr)
 		var color tcell.Color
 		if colorStr == "default" {


### PR DESCRIPTION
To get a new theme for Amfora, I went to the [theme page](https://github.com/makeworld-the-better-one/amfora/tree/master/contrib/themes), I downloaded one and I used the `include` key to import it. I want to use the `include` key because it feels way more convenient than copy-pasting a theme in the configuration file.

When the `include` directive was not under the `[theme]` tag, it was ignored, when the `include` key was under the `[theme]` tag, I got the following error:
```
Config error: invalid color format for "include": <My home folder>/.config/amfora/one_dark.toml
```

This PR make so that the theme parser ignores the `include` keys in order to prevent the error.
