### PR TITLE
add confirmation prompts for url schemes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -257,7 +257,7 @@ func Init() error {
 	viper.SetDefault("keybindings.shift_numbers", "")
 	viper.SetDefault("keybindings.bind_url_handler_open", "Ctrl-U")
 	viper.SetDefault("url-handlers.other", "default")
-	viper.SetDefault("url-prompts.default", false)
+	viper.SetDefault("url-prompts.other", false)
 	viper.SetDefault("cache.max_size", 0)
 	viper.SetDefault("cache.max_pages", 20)
 	viper.SetDefault("cache.timeout", 1800)

--- a/config/config.go
+++ b/config/config.go
@@ -257,6 +257,7 @@ func Init() error {
 	viper.SetDefault("keybindings.shift_numbers", "")
 	viper.SetDefault("keybindings.bind_url_handler_open", "Ctrl-U")
 	viper.SetDefault("url-handlers.other", "default")
+	viper.SetDefault("url-prompts.default", false)
 	viper.SetDefault("cache.max_size", 0)
 	viper.SetDefault("cache.max_pages", 20)
 	viper.SetDefault("cache.timeout", 1800)

--- a/config/default.go
+++ b/config/default.go
@@ -218,6 +218,18 @@ underline = true
 # application on your computer for opening this kind of URI.
 other = 'default'
 
+[url-prompts]
+# Specify whether a confirmation prompt should be shown before following URL schemes.
+# The special key 'other' matches all schemes that don't match any other key.
+#
+# Example: prompt on every non-gemini URL
+# other = true
+# gemini = false
+#
+# Example: only prompt on HTTP(S)
+# other = false
+# http = true
+# https = true
 
 # [[mediatype-handlers]] section
 # ---------------------------------

--- a/default-config.toml
+++ b/default-config.toml
@@ -215,6 +215,18 @@ underline = true
 # application on your computer for opening this kind of URI.
 other = 'default'
 
+[url-prompts]
+# Specify whether a confirmation prompt should be shown before following URL schemes.
+# The special key 'other' matches all schemes that don't match any other key.
+#
+# Example: prompt on every non-gemini URL
+# other = true
+# gemini = false
+#
+# Example: only prompt on HTTP(S)
+# other = false
+# http = true
+# https = true
 
 # [[mediatype-handlers]] section
 # ---------------------------------

--- a/display/handlers.go
+++ b/display/handlers.go
@@ -252,6 +252,15 @@ func handleURL(t *tab, u string, numRedirects int) (string, bool) {
 		return ret("", false)
 	}
 
+	// check if a prompt is needed to handle this url
+	prompt := viper.GetBool("url-prompts.default")
+	if viper.IsSet("url-prompts." + parsed.Scheme) {
+		prompt = viper.GetBool("url-prompts." + parsed.Scheme)
+	}
+	if prompt && !(YesNo("Follow URL?\n" + u)) {
+		return ret("", false)
+	}
+
 	proxy := strings.TrimSpace(viper.GetString("proxies." + parsed.Scheme))
 	usingProxy := false
 

--- a/display/handlers.go
+++ b/display/handlers.go
@@ -253,7 +253,7 @@ func handleURL(t *tab, u string, numRedirects int) (string, bool) {
 	}
 
 	// check if a prompt is needed to handle this url
-	prompt := viper.GetBool("url-prompts.default")
+	prompt := viper.GetBool("url-prompts.other")
 	if viper.IsSet("url-prompts." + parsed.Scheme) {
 		prompt = viper.GetBool("url-prompts." + parsed.Scheme)
 	}


### PR DESCRIPTION
This commit adds a confirmation prompt before following urls with
with certain schemes.
Wether or not a scheme requires confirmation can be configured in the
new `[url-promps]` section.

For #301