### PR TITLE
Add half_pgup and half_pgdn bindings

### DIFF
--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -49,6 +49,8 @@ const (
 	CmdMoveRight
 	CmdPgup
 	CmdPgdn
+	CmdHalfPgup
+	CmdHalfPgdn
 	CmdNewTab
 	CmdCloseTab
 	CmdNextTab
@@ -187,6 +189,8 @@ func KeyInit() {
 		CmdMoveRight:      "keybindings.bind_moveright",
 		CmdPgup:           "keybindings.bind_pgup",
 		CmdPgdn:           "keybindings.bind_pgdn",
+		CmdHalfPgup:       "keybindings.bind_half_pgup",
+		CmdHalfPgdn:       "keybindings.bind_half_pgdn",
 		CmdNewTab:         "keybindings.bind_new_tab",
 		CmdCloseTab:       "keybindings.bind_close_tab",
 		CmdNextTab:        "keybindings.bind_next_tab",

--- a/default-config.toml
+++ b/default-config.toml
@@ -173,6 +173,8 @@ underline = true
 # bind_moveright
 # bind_pgup
 # bind_pgdn
+# bind_half_pgup
+# bind_half_pgdn
 # bind_new_tab
 # bind_close_tab
 # bind_next_tab

--- a/display/help.go
+++ b/display/help.go
@@ -16,6 +16,8 @@ var helpCells = strings.TrimSpace(
 		"Arrow keys, %s(left)/%s(down)/%s(up)/%s(right)\tScroll and move a page.\n" +
 		"%s\tGo up a page in document\n" +
 		"%s\tGo down a page in document\n" +
+		"%s\tGo up half a page in document\n" +
+		"%s\tGo down half a page in document\n" +
 		"%s\tGo to top of document\n" +
 		"%s\tGo to bottom of document\n" +
 		"Tab\tNavigate to the next item in a popup.\n" +
@@ -87,6 +89,8 @@ func helpInit() {
 		config.GetKeyBinding(config.CmdMoveRight),
 		config.GetKeyBinding(config.CmdPgup),
 		config.GetKeyBinding(config.CmdPgdn),
+		config.GetKeyBinding(config.CmdHalfPgup),
+		config.GetKeyBinding(config.CmdHalfPgdn),
 		config.GetKeyBinding(config.CmdBeginning),
 		config.GetKeyBinding(config.CmdEnd),
 		config.GetKeyBinding(config.CmdBack),

--- a/display/tab.go
+++ b/display/tab.go
@@ -166,6 +166,12 @@ func makeNewTab() *tab {
 		case config.CmdPgdn:
 			t.pageDown()
 			return nil
+		case config.CmdHalfPgup:
+			t.halfPageUp()
+			return nil
+		case config.CmdHalfPgdn:
+			t.halfPageDown()
+			return nil
 		case config.CmdSave:
 			if t.hasContent() {
 				savePath, err := downloadPage(t.page)
@@ -350,25 +356,40 @@ func (t *tab) addToHistory(u string) {
 	t.historyCachePage()                                                      // Fill it with data
 }
 
-// pageUp scrolls up 75% of the height of the terminal, like Bombadillo.
-func (t *tab) pageUp() {
-	t.page.Row -= (termH / 4) * 3
+// Scrolls by the given fraction of the display height
+func (t *tab) relativeScroll(scrollAmount float32) {
+	t.page.Row += int(float32(termH) * scrollAmount)
+
+	// Clamp to page bounds
+	height, _ := t.view.GetBufferSize()
 	if t.page.Row < 0 {
 		t.page.Row = 0
 	}
-	t.applyScroll()
-}
-
-// pageDown scrolls down 75% of the height of the terminal, like Bombadillo.
-func (t *tab) pageDown() {
-	height, _ := t.view.GetBufferSize()
-
-	t.page.Row += (termH / 4) * 3
 	if t.page.Row > height {
 		t.page.Row = height
 	}
 
 	t.applyScroll()
+}
+
+// pageUp scrolls up 75% of the height of the terminal, like Bombadillo.
+func (t *tab) pageUp() {
+	t.relativeScroll(-0.75)
+}
+
+// pageDown scrolls down 75% of the height of the terminal, like Bombadillo.
+func (t *tab) pageDown() {
+	t.relativeScroll(0.75)
+}
+
+// halfPageUp scrolls up 50% of the height of the terminal, like vim and less.
+func (t *tab) halfPageUp() {
+	t.relativeScroll(-0.5)
+}
+
+// halfPageDown scrolls down 75% of the height of the terminal, like vim and less.
+func (t *tab) halfPageDown() {
+	t.relativeScroll(0.5)
 }
 
 // hasContent returns false when the tab's page is malformed,


### PR DESCRIPTION
Adds `half_pgup` and `half_pgdn` bindings (`CmdHalfPgup` and `CmdHalfPgdn`), which scroll by half a page, like vim and less. These are unbound by default, but are listed in the default config file and have a help entry.

This was implemented by refactoring `pageUp` and `pageDown` into a generic `relativeScroll` method called by all page up/down functions. There's a change that the float conversions might not yield exactly the same scroll distance, but it shouldn't be off by more than a line if so.

Fixes #303