### PR TITLE
Add Ayu Light theme

### DIFF
--- a/contrib/themes/README.md
+++ b/contrib/themes/README.md
@@ -106,6 +106,21 @@ Contributed by **[@sergetymo](https://github.com/sergetymo)**.
 ![screenshot of error modal](https://user-images.githubusercontent.com/65758149/101183206-da73aa00-3657-11eb-8733-5040c8aefb99.png)
 </details>
 
+## Ayu Light
+Contributed by **[@sergetymo](https://github.com/sergetymo)**.
+
+TODO: Update screenshots
+
+![screenshot of one dark theme](https://user-images.githubusercontent.com/65758149/101183151-c8920700-3657-11eb-87f5-7d1d6ae616f2.png)
+
+<details>
+<summary>More screenshots</summary>
+
+![screenshot of bookmark modal](https://user-images.githubusercontent.com/65758149/101183267-f8410f00-3657-11eb-97fa-10f88a9d8de4.png)
+![screenshot of error modal](https://user-images.githubusercontent.com/65758149/101183206-da73aa00-3657-11eb-8733-5040c8aefb99.png)
+</details>
+
+
 ## Atelier Forest
 
 Contributed by **[@joyalicegu](https://github.com/joyalicegu)**.

--- a/contrib/themes/README.md
+++ b/contrib/themes/README.md
@@ -109,15 +109,13 @@ Contributed by **[@sergetymo](https://github.com/sergetymo)**.
 ## Ayu Light
 Contributed by **[@sergetymo](https://github.com/sergetymo)**.
 
-TODO: Update screenshots
-
-![screenshot of one dark theme](https://user-images.githubusercontent.com/65758149/101183151-c8920700-3657-11eb-87f5-7d1d6ae616f2.png)
+![screenshot of Ayu Light theme](https://user-images.githubusercontent.com/65758149/181745417-48a92840-10d2-4659-950d-fbc9b3588d5c.png)
 
 <details>
 <summary>More screenshots</summary>
 
-![screenshot of bookmark modal](https://user-images.githubusercontent.com/65758149/101183267-f8410f00-3657-11eb-97fa-10f88a9d8de4.png)
-![screenshot of error modal](https://user-images.githubusercontent.com/65758149/101183206-da73aa00-3657-11eb-8733-5040c8aefb99.png)
+![screenshot of bookmark modal](https://user-images.githubusercontent.com/65758149/181745413-b5a15120-2ff6-4879-8539-0f02f0eece21.png)
+![screenshot of error modal](https://user-images.githubusercontent.com/65758149/181745400-c3e9ba95-aee4-4956-91a8-3dddcbad48cc.png)
 </details>
 
 

--- a/contrib/themes/ayu_light.toml
+++ b/contrib/themes/ayu_light.toml
@@ -1,0 +1,56 @@
+# Ayu Light theme ported to Amfora
+# by Serge Tymoshenko <serge@tymo.name>
+
+bg = "#fcfcfc"
+fg = "#5c6166"
+tab_num = "#5c6166"
+tab_divider = "#5c6166"
+bottombar_bg = "#fcfcfc"
+bottombar_text = "#5c6166"
+bottombar_label = "#5c6166"
+
+hdg_1 = "#fa8d3e"
+hdg_2 = "#f2ae49"
+hdg_3 = "#f2ae49"
+amfora_link = "#399ee6"
+foreign_link = "#a37acc"
+link_number = "#5c6166"
+regular_text = "#5c6166"
+quote_text = "#4cbf99"
+preformatted_text = "#86b300"
+list_text = "#5c6166"
+
+btn_bg = "#55b4d4"
+btn_text = "#fcfcfc"
+
+dl_choice_modal_bg = "#f2ae49"
+dl_choice_modal_text = "#fcfcfc"
+
+dl_modal_bg = "#f2ae49"
+dl_modal_text = "#fcfcfc"
+
+info_modal_bg = "#f2ae49"
+info_modal_text = "#fcfcfc"
+
+error_modal_bg = "#f07171"
+error_modal_text = "#fcfcfc"
+
+yesno_modal_bg = "#f2ae49"
+yesno_modal_text = "#fcfcfc"
+
+tofu_modal_bg = "#ed9366"
+tofu_modal_text = "#282c34"
+
+input_modal_bg = "#f2ae49"
+input_modal_text = "#fcfcfc"
+input_modal_field_bg = "#e6ba7e"
+input_modal_field_text = "#5c6166"
+
+bkmk_modal_bg = "#f2ae49"
+bkmk_modal_text = "#fcfcfc"
+bkmk_modal_label = "#fcfcfc"
+bkmk_modal_field_bg = "#e6ba7e"
+bkmk_modal_field_text = "#5c6166"
+
+subscription_modal_bg = "#f2ae49"
+subscription_modal_text = "#5c6166"


### PR DESCRIPTION
My port of light variant of [Ayu theme](https://github.com/dempfi/ayu).

<img width="840" alt="Screenshot 2022-07-29 at 13 44 01" src="https://user-images.githubusercontent.com/65758149/181745417-48a92840-10d2-4659-950d-fbc9b3588d5c.png">
<img width="840" alt="Screenshot 2022-07-29 at 13 44 13" src="https://user-images.githubusercontent.com/65758149/181745413-b5a15120-2ff6-4879-8539-0f02f0eece21.png">
<img width="840" alt="Screenshot 2022-07-29 at 13 46 56" src="https://user-images.githubusercontent.com/65758149/181745400-c3e9ba95-aee4-4956-91a8-3dddcbad48cc.png">



